### PR TITLE
Fix comment text in example config

### DIFF
--- a/example-fog.yaml
+++ b/example-fog.yaml
@@ -17,7 +17,7 @@ tags:
     Source: https://github.com/ArjenSchwarz/fog/$TEMPLATEPATH # An example tag to be added
   directory: tags # The directory where you store your parameter files. Relative to where you run the application from
   extensions:
-    - .json # The extensions for your ta files. Only json formatted files are currently supported
+    - .json # The extensions for your tag files. Only json formatted files are currently supported
 templates:
   directory: templates # The directory where you store your template files. Relative to where you run the application from
   extensions: # The extensions for your template files. Both yaml and json formatted files are currently supported


### PR DESCRIPTION
## Summary
- fix comment in example config to say "tag files"

## Testing
- `go test ./...` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840387d708483338da5670cb408fcbb