### PR TITLE
Fix CompareRoutes nil pointer

### DIFF
--- a/lib/ec2.go
+++ b/lib/ec2.go
@@ -143,7 +143,7 @@ func CompareRoutes(route1 types.Route, route2 types.Route, blackholeIgnore []str
 	}
 	if string(route1.State) != string(route2.State) {
 		// If the route is a blackhole and the destination is in the ignore list, consider it a match
-		if route1.State == types.RouteStateBlackhole && stringInSlice(*route1.VpcPeeringConnectionId, blackholeIgnore) {
+		if route1.State == types.RouteStateBlackhole && route1.VpcPeeringConnectionId != nil && stringInSlice(*route1.VpcPeeringConnectionId, blackholeIgnore) {
 			return true
 		}
 		return false

--- a/lib/ec2_test.go
+++ b/lib/ec2_test.go
@@ -262,6 +262,12 @@ func TestCompareRoutes(t *testing.T) {
 	state.State = types.RouteStateBlackhole
 	origin := fullRoute
 	origin.Origin = types.RouteOriginCreateRouteTable
+	noppeer := fullRoute
+	noppeer.VpcPeeringConnectionId = nil
+	noppeer.State = types.RouteStateBlackhole
+	noppeerActive := noppeer
+	noppeerActive.State = types.RouteStateActive
+	noppeerBlackhole := noppeer
 	tests := []struct {
 		name string
 		args args
@@ -286,6 +292,8 @@ func TestCompareRoutes(t *testing.T) {
 		{"Different value VpcPeeringConnectionId", args{route1: fullRoute, route2: peer}, false},
 		{"Different value State", args{route1: fullRoute, route2: state}, false},
 		{"Different value Origin", args{route1: fullRoute, route2: origin}, false},
+		{"Nil VpcPeeringConnectionId with Blackhole state", args{route1: noppeer, route2: noppeerActive}, false},
+		{"Nil VpcPeeringConnectionId with same state", args{route1: noppeer, route2: noppeerBlackhole}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- guard against nil VpcPeeringConnectionId in CompareRoutes
- ensure CompareRoutes behaves correctly when VpcPeeringConnectionId is nil

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68403870d9b0833384554d6d418535cd