### PR TITLE
Refactor resource fetching to use interfaces

### DIFF
--- a/lib/drift.go
+++ b/lib/drift.go
@@ -58,7 +58,10 @@ func GetDefaultStackDrift(stackName *string, svc *cloudformation.Client) []types
 	return allDrifts
 }
 
-func GetUncheckedStackResources(stackName *string, checkedResources []string, svc *cloudformation.Client) []CfnResource {
+func GetUncheckedStackResources(stackName *string, checkedResources []string, svc interface {
+	CloudFormationDescribeStacksAPI
+	CloudFormationDescribeStackResourcesAPI
+}) []CfnResource {
 	resources := GetResources(stackName, svc)
 	uncheckedresources := []CfnResource{}
 	for _, resource := range resources {

--- a/lib/drift_test.go
+++ b/lib/drift_test.go
@@ -24,14 +24,6 @@ type CloudFormationDescribeStackResourceDriftsAPI interface {
 	DescribeStackResourceDrifts(ctx context.Context, params *cloudformation.DescribeStackResourceDriftsInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourceDriftsOutput, error)
 }
 
-type CloudFormationDescribeStacksAPI interface {
-	DescribeStacks(ctx context.Context, params *cloudformation.DescribeStacksInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error)
-}
-
-type CloudFormationDescribeStackResourcesAPI interface {
-	DescribeStackResources(ctx context.Context, params *cloudformation.DescribeStackResourcesInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error)
-}
-
 // MockCloudFormationClient is a mock implementation of the CloudFormation client
 type MockCloudFormationClient struct {
 	DetectStackDriftOutput                  cloudformation.DetectStackDriftOutput

--- a/lib/interfaces.go
+++ b/lib/interfaces.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 )
 
@@ -16,4 +17,12 @@ type EC2DescribeRouteTablesAPI interface {
 
 type EC2DescribeManagedPrefixListsAPI interface {
 	DescribeManagedPrefixLists(ctx context.Context, params *ec2.DescribeManagedPrefixListsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeManagedPrefixListsOutput, error)
+}
+
+type CloudFormationDescribeStacksAPI interface {
+	DescribeStacks(ctx context.Context, params *cloudformation.DescribeStacksInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error)
+}
+
+type CloudFormationDescribeStackResourcesAPI interface {
+	DescribeStackResources(ctx context.Context, params *cloudformation.DescribeStackResourcesInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error)
 }

--- a/lib/resources.go
+++ b/lib/resources.go
@@ -21,9 +21,12 @@ type CfnResource struct {
 	Status     string
 }
 
-// GetResources returns all the exports in the account and region. If stackname
+// GetResources returns all the resources in the account and region. If stackname
 // is provided, results will be limited to that stack.
-func GetResources(stackname *string, svc *cloudformation.Client) []CfnResource {
+func GetResources(stackname *string, svc interface {
+	CloudFormationDescribeStacksAPI
+	CloudFormationDescribeStackResourcesAPI
+}) []CfnResource {
 	input := &cloudformation.DescribeStacksInput{}
 	if *stackname != "" && !strings.Contains(*stackname, "*") {
 		input.StackName = stackname

--- a/lib/resources_test.go
+++ b/lib/resources_test.go
@@ -1,0 +1,64 @@
+package lib
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+)
+
+type mockCloudFormationClient struct {
+	describeStacksOutput         cloudformation.DescribeStacksOutput
+	describeStackResourcesOutput cloudformation.DescribeStackResourcesOutput
+}
+
+func (m *mockCloudFormationClient) DescribeStacks(ctx context.Context, params *cloudformation.DescribeStacksInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+	return &m.describeStacksOutput, nil
+}
+
+func (m *mockCloudFormationClient) DescribeStackResources(ctx context.Context, params *cloudformation.DescribeStackResourcesInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error) {
+	return &m.describeStackResourcesOutput, nil
+}
+
+func TestGetResources(t *testing.T) {
+	mock := &mockCloudFormationClient{
+		describeStacksOutput: cloudformation.DescribeStacksOutput{
+			Stacks: []types.Stack{
+				{StackName: aws.String("test-stack")},
+			},
+		},
+		describeStackResourcesOutput: cloudformation.DescribeStackResourcesOutput{
+			StackResources: []types.StackResource{
+				{
+					PhysicalResourceId: aws.String("resource-id"),
+					LogicalResourceId:  aws.String("logical-id"),
+					ResourceType:       aws.String("AWS::S3::Bucket"),
+					ResourceStatus:     types.ResourceStatusCreateComplete,
+				},
+			},
+		},
+	}
+
+	stackName := "test-stack"
+	got := GetResources(&stackName, mock)
+
+	want := []CfnResource{
+		{
+			StackName:  "test-stack",
+			Type:       "AWS::S3::Bucket",
+			ResourceID: "resource-id",
+			LogicalID:  "logical-id",
+			Status:     "CREATE_COMPLETE",
+		},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d resources, got %d", len(want), len(got))
+	}
+
+	if got[0] != want[0] {
+		t.Errorf("unexpected resource: got %+v, want %+v", got[0], want[0])
+	}
+}


### PR DESCRIPTION
## Summary
- add CloudFormation interfaces for describing stacks and stack resources
- refactor `GetResources` and `GetUncheckedStackResources` to use the interfaces
- update tests to use the new interfaces
- add unit test for `GetResources`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684048509f508333a4d378cb5f9060a4