### PR TITLE
[feature] Introduce command registry

### DIFF
--- a/cmd/registry/builder.go
+++ b/cmd/registry/builder.go
@@ -6,6 +6,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// contextKey is the type used for values stored in context.Context.
+// Using a custom type prevents collisions with keys from other packages.
+type contextKey string
+
+const (
+	commandCtxKey contextKey = "command"
+	argsCtxKey    contextKey = "args"
+)
+
 // Middleware defines a command middleware.
 type Middleware interface {
 	Execute(ctx context.Context, next func(context.Context) error) error
@@ -70,8 +79,8 @@ func (b *BaseCommandBuilder) GetHandler() CommandHandler { return b.handler }
 
 func (b *BaseCommandBuilder) createRunFunc() func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		ctx := context.WithValue(context.Background(), "command", cmd)
-		ctx = context.WithValue(ctx, "args", args)
+		ctx := context.WithValue(context.Background(), commandCtxKey, cmd)
+		ctx = context.WithValue(ctx, argsCtxKey, args)
 
 		handler := func(ctx context.Context) error {
 			if b.validator != nil {

--- a/cmd/registry/builder.go
+++ b/cmd/registry/builder.go
@@ -1,0 +1,98 @@
+package registry
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+// Middleware defines a command middleware.
+type Middleware interface {
+	Execute(ctx context.Context, next func(context.Context) error) error
+}
+
+// BaseCommandBuilder provides common logic for command builders.
+type BaseCommandBuilder struct {
+	name        string
+	short       string
+	long        string
+	handler     CommandHandler
+	validator   FlagValidator
+	middlewares []Middleware
+}
+
+// NewBaseCommandBuilder creates a new builder with the given name and descriptions.
+func NewBaseCommandBuilder(name, short, long string) *BaseCommandBuilder {
+	return &BaseCommandBuilder{
+		name:        name,
+		short:       short,
+		long:        long,
+		middlewares: make([]Middleware, 0),
+	}
+}
+
+// WithHandler assigns the command handler.
+func (b *BaseCommandBuilder) WithHandler(handler CommandHandler) *BaseCommandBuilder {
+	b.handler = handler
+	return b
+}
+
+// WithValidator assigns a flag validator.
+func (b *BaseCommandBuilder) WithValidator(validator FlagValidator) *BaseCommandBuilder {
+	b.validator = validator
+	return b
+}
+
+// WithMiddleware appends a middleware to the chain.
+func (b *BaseCommandBuilder) WithMiddleware(m Middleware) *BaseCommandBuilder {
+	b.middlewares = append(b.middlewares, m)
+	return b
+}
+
+// BuildCommand constructs the cobra command including flags and middleware chain.
+func (b *BaseCommandBuilder) BuildCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   b.name,
+		Short: b.short,
+		Long:  b.long,
+		RunE:  b.createRunFunc(),
+	}
+
+	if b.validator != nil {
+		b.validator.RegisterFlags(cmd)
+	}
+
+	return cmd
+}
+
+// GetHandler returns the associated handler.
+func (b *BaseCommandBuilder) GetHandler() CommandHandler { return b.handler }
+
+func (b *BaseCommandBuilder) createRunFunc() func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		ctx := context.WithValue(context.Background(), "command", cmd)
+		ctx = context.WithValue(ctx, "args", args)
+
+		handler := func(ctx context.Context) error {
+			if b.validator != nil {
+				if err := b.validator.Validate(); err != nil {
+					return err
+				}
+			}
+			if b.handler == nil {
+				return nil
+			}
+			return b.handler.Execute(ctx)
+		}
+
+		for i := len(b.middlewares) - 1; i >= 0; i-- {
+			mw := b.middlewares[i]
+			next := handler
+			handler = func(ctx context.Context) error {
+				return mw.Execute(ctx, next)
+			}
+		}
+
+		return handler(ctx)
+	}
+}

--- a/cmd/registry/builder_test.go
+++ b/cmd/registry/builder_test.go
@@ -1,0 +1,70 @@
+package registry
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type testHandler struct{ calls *[]string }
+
+func (h *testHandler) Execute(_ context.Context) error {
+	*h.calls = append(*h.calls, "handler")
+	return nil
+}
+func (h *testHandler) ValidateFlags() error { return nil }
+
+type testValidator struct {
+	registered bool
+	calls      *[]string
+}
+
+func (v *testValidator) Validate() error {
+	*v.calls = append(*v.calls, "validate")
+	return nil
+}
+func (v *testValidator) RegisterFlags(cmd *cobra.Command) {
+	v.registered = true
+	cmd.Flags().Bool("x", false, "")
+}
+
+type testMiddleware struct {
+	id    string
+	calls *[]string
+}
+
+func (m testMiddleware) Execute(ctx context.Context, next func(context.Context) error) error {
+	*m.calls = append(*m.calls, m.id+" before")
+	err := next(ctx)
+	*m.calls = append(*m.calls, m.id+" after")
+	return err
+}
+
+func TestBaseCommandBuilder_Run(t *testing.T) {
+	order := []string{}
+	h := &testHandler{calls: &order}
+	v := &testValidator{calls: &order}
+	m1 := testMiddleware{id: "m1", calls: &order}
+	m2 := testMiddleware{id: "m2", calls: &order}
+
+	b := NewBaseCommandBuilder("test", "", "").
+		WithHandler(h).
+		WithValidator(v).
+		WithMiddleware(m1).
+		WithMiddleware(m2)
+
+	cmd := b.BuildCommand()
+	if !v.registered {
+		t.Errorf("validator did not register flags")
+	}
+	if err := cmd.RunE(cmd, []string{}); err != nil {
+		t.Fatalf("command run failed: %v", err)
+	}
+
+	expected := []string{"m1 before", "m2 before", "validate", "handler", "m2 after", "m1 after"}
+	if !reflect.DeepEqual(order, expected) {
+		t.Errorf("execution order mismatch\nwant %v\n got %v", expected, order)
+	}
+}

--- a/cmd/registry/builder_test.go
+++ b/cmd/registry/builder_test.go
@@ -43,20 +43,20 @@ func (m testMiddleware) Execute(ctx context.Context, next func(context.Context) 
 }
 
 func TestBaseCommandBuilder_Run(t *testing.T) {
-	order := []string{}
-	h := &testHandler{calls: &order}
-	v := &testValidator{calls: &order}
-	m1 := testMiddleware{id: "m1", calls: &order}
-	m2 := testMiddleware{id: "m2", calls: &order}
+	executionOrder := []string{}
+	handler := &testHandler{calls: &executionOrder}
+	validator := &testValidator{calls: &executionOrder}
+	middleware1 := testMiddleware{id: "m1", calls: &executionOrder}
+	middleware2 := testMiddleware{id: "m2", calls: &executionOrder}
 
-	b := NewBaseCommandBuilder("test", "", "").
-		WithHandler(h).
-		WithValidator(v).
-		WithMiddleware(m1).
-		WithMiddleware(m2)
+	builder := NewBaseCommandBuilder("test", "", "").
+		WithHandler(handler).
+		WithValidator(validator).
+		WithMiddleware(middleware1).
+		WithMiddleware(middleware2)
 
-	cmd := b.BuildCommand()
-	if !v.registered {
+	cmd := builder.BuildCommand()
+	if !validator.registered {
 		t.Errorf("validator did not register flags")
 	}
 	if err := cmd.RunE(cmd, []string{}); err != nil {
@@ -64,7 +64,7 @@ func TestBaseCommandBuilder_Run(t *testing.T) {
 	}
 
 	expected := []string{"m1 before", "m2 before", "validate", "handler", "m2 after", "m1 after"}
-	if !reflect.DeepEqual(order, expected) {
-		t.Errorf("execution order mismatch\nwant %v\n got %v", expected, order)
+	if !reflect.DeepEqual(executionOrder, expected) {
+		t.Errorf("execution order mismatch\nwant %v\n got %v", expected, executionOrder)
 	}
 }

--- a/cmd/registry/interfaces.go
+++ b/cmd/registry/interfaces.go
@@ -1,0 +1,25 @@
+package registry
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+)
+
+// CommandHandler defines the interface for command business logic.
+type CommandHandler interface {
+	Execute(ctx context.Context) error
+	ValidateFlags() error
+}
+
+// CommandBuilder describes how to build a cobra command.
+type CommandBuilder interface {
+	BuildCommand() *cobra.Command
+	GetHandler() CommandHandler
+}
+
+// FlagValidator defines validation and flag registration behaviour.
+type FlagValidator interface {
+	Validate() error
+	RegisterFlags(cmd *cobra.Command)
+}

--- a/cmd/registry/registry.go
+++ b/cmd/registry/registry.go
@@ -1,0 +1,42 @@
+package registry
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// CommandRegistry manages registration of command builders.
+type CommandRegistry struct {
+	builders map[string]CommandBuilder
+	rootCmd  *cobra.Command
+}
+
+// NewCommandRegistry creates a new registry associated with the provided root command.
+func NewCommandRegistry(rootCmd *cobra.Command) *CommandRegistry {
+	return &CommandRegistry{
+		builders: make(map[string]CommandBuilder),
+		rootCmd:  rootCmd,
+	}
+}
+
+// Register adds a builder to the registry.
+func (r *CommandRegistry) Register(name string, builder CommandBuilder) error {
+	if _, exists := r.builders[name]; exists {
+		return fmt.Errorf("command %s already registered", name)
+	}
+	r.builders[name] = builder
+	return nil
+}
+
+// BuildAll constructs all registered commands and attaches them to the root.
+func (r *CommandRegistry) BuildAll() error {
+	for name, builder := range r.builders {
+		cmd := builder.BuildCommand()
+		if cmd == nil {
+			return fmt.Errorf("builder for %s returned nil command", name)
+		}
+		r.rootCmd.AddCommand(cmd)
+	}
+	return nil
+}

--- a/cmd/registry/registry_test.go
+++ b/cmd/registry/registry_test.go
@@ -20,17 +20,17 @@ func (nilBuilder) GetHandler() CommandHandler   { return nil }
 
 func TestRegistryRegisterAndBuild(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
-	r := NewCommandRegistry(root)
+	registry := NewCommandRegistry(root)
 
-	if err := r.Register("test", stubBuilder{cmd: &cobra.Command{Use: "test"}}); err != nil {
+	if err := registry.Register("test", stubBuilder{cmd: &cobra.Command{Use: "test"}}); err != nil {
 		t.Fatalf("unexpected register error: %v", err)
 	}
 
-	if err := r.Register("test", stubBuilder{cmd: &cobra.Command{Use: "test"}}); err == nil {
+	if err := registry.Register("test", stubBuilder{cmd: &cobra.Command{Use: "test"}}); err == nil {
 		t.Errorf("expected error on duplicate registration")
 	}
 
-	if err := r.BuildAll(); err != nil {
+	if err := registry.BuildAll(); err != nil {
 		t.Fatalf("unexpected build error: %v", err)
 	}
 	if len(root.Commands()) != 1 {
@@ -43,11 +43,11 @@ func TestRegistryRegisterAndBuild(t *testing.T) {
 
 func TestRegistryBuildAllNilCommand(t *testing.T) {
 	root := &cobra.Command{Use: "root"}
-	r := NewCommandRegistry(root)
-	if err := r.Register("bad", nilBuilder{}); err != nil {
+	registry := NewCommandRegistry(root)
+	if err := registry.Register("bad", nilBuilder{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if err := r.BuildAll(); err == nil {
+	if err := registry.BuildAll(); err == nil {
 		t.Errorf("expected error when builder returns nil")
 	}
 }

--- a/cmd/registry/registry_test.go
+++ b/cmd/registry/registry_test.go
@@ -1,0 +1,53 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+type stubBuilder struct {
+	cmd *cobra.Command
+}
+
+func (s stubBuilder) BuildCommand() *cobra.Command { return s.cmd }
+func (s stubBuilder) GetHandler() CommandHandler   { return nil }
+
+type nilBuilder struct{}
+
+func (nilBuilder) BuildCommand() *cobra.Command { return nil }
+func (nilBuilder) GetHandler() CommandHandler   { return nil }
+
+func TestRegistryRegisterAndBuild(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	r := NewCommandRegistry(root)
+
+	if err := r.Register("test", stubBuilder{cmd: &cobra.Command{Use: "test"}}); err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+
+	if err := r.Register("test", stubBuilder{cmd: &cobra.Command{Use: "test"}}); err == nil {
+		t.Errorf("expected error on duplicate registration")
+	}
+
+	if err := r.BuildAll(); err != nil {
+		t.Fatalf("unexpected build error: %v", err)
+	}
+	if len(root.Commands()) != 1 {
+		t.Fatalf("expected command added to root")
+	}
+	if root.Commands()[0].Use != "test" {
+		t.Errorf("command use mismatch")
+	}
+}
+
+func TestRegistryBuildAllNilCommand(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	r := NewCommandRegistry(root)
+	if err := r.Register("bad", nilBuilder{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := r.BuildAll(); err == nil {
+		t.Errorf("expected error when builder returns nil")
+	}
+}


### PR DESCRIPTION
## Summary
- add interfaces for command registry
- implement command registry with BuildAll
- create base command builder with middleware support
- add unit tests for registry and builder

## Testing
- `go test ./cmd/registry -v`
- `go mod download` *(fails: no internet access)*
- `go test ./... -v` *(fails: unable to download modules)*
- `golangci-lint run` *(fails: command not found or dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb5a014c8333929f01f391e07627