### PR TITLE
[refactor] update command migration docs

### DIFF
--- a/cmd/commands/README.md
+++ b/cmd/commands/README.md
@@ -1,0 +1,27 @@
+# Command Structure Migration Guide
+
+## Overview
+This directory contains the new command structure for the fog CLI application.
+
+## Structure
+Each command is organized in its own directory with:
+- `command.go` - Command builder and definition
+- `handler.go` - Business logic handler
+- `flags.go` - Flag definitions and validation
+
+## Migration Status
+- [x] Deploy command - Refactored with new structure
+- [ ] Drift command - TODO
+- [ ] Describe command - TODO
+- [ ] Dependencies command - TODO
+- [ ] Exports command - TODO
+- [ ] History command - TODO
+- [ ] Report command - TODO
+- [ ] Resources command - TODO
+
+## Adding New Commands
+1. Create directory under `cmd/commands/`
+2. Implement the three required files
+3. Register in `cmd/root.go`
+4. Add tests in `cmd/testing/`
+

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
@@ -50,6 +51,9 @@ var (
 		Short: "Utility commands",
 		Long:  `Utility commands for various helper functions.`,
 	}
+
+	// Names of commands already migrated to the new registry-based structure
+	migratedStackCommands = []string{"deploy"}
 )
 
 // InitGroups initializes all command groups and adds them to the root command
@@ -58,6 +62,14 @@ func InitGroups() {
 	rootCmd.AddCommand(stackCmd)
 	rootCmd.AddCommand(resourceGroupCmd)
 	rootCmd.AddCommand(utilGroupCmd)
+
+	// For migrated commands in the stack group, create aliases so old paths
+	// continue to work while the new command registry attaches them at the
+	// root level.
+	for _, name := range migratedStackCommands {
+		short := fmt.Sprintf("Alias for '%s'", name)
+		stackCmd.AddCommand(NewCommandAlias(name, name, short))
+	}
 }
 
 // NewCommandAlias creates a command that redirects to another command path


### PR DESCRIPTION
## Summary
- add migration guide for new command structure
- make command groups interoperate with new registry

## Testing
- `go test ./... -v`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68436a30d19883339ea3e18ca7a51e5c