### PR TITLE
[test] expand command testing

### DIFF
--- a/cmd/commands/deploy/command_integration_test.go
+++ b/cmd/commands/deploy/command_integration_test.go
@@ -1,0 +1,43 @@
+package deploy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// buildRoot creates a root command with the deploy command registered.
+func buildRoot() *cobra.Command {
+	root := &cobra.Command{Use: "root"}
+	builder := NewCommandBuilder()
+	root.AddCommand(builder.BuildCommand())
+	return root
+}
+
+func TestDeployCommandExecuteValid(t *testing.T) {
+	root := buildRoot()
+	root.SetArgs([]string{"deploy", "--stackname", "test"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "not yet implemented") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeployCommandExecuteMissingStack(t *testing.T) {
+	root := buildRoot()
+	root.SetArgs([]string{"deploy"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "stack name is required") {
+		t.Fatalf("expected validation error, got: %v", err)
+	}
+}
+
+func TestDeployCommandExecuteConflictingFlags(t *testing.T) {
+	root := buildRoot()
+	root.SetArgs([]string{"deploy", "--stackname", "s", "--deployment-file", "f", "--template", "t"})
+	err := root.Execute()
+	if err == nil || !strings.Contains(err.Error(), "deployment file") {
+		t.Fatalf("expected conflict error, got: %v", err)
+	}
+}

--- a/cmd/commands/deploy/flags_test.go
+++ b/cmd/commands/deploy/flags_test.go
@@ -1,0 +1,28 @@
+package deploy
+
+import "testing"
+
+func TestFlagsValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		flags   Flags
+		wantErr bool
+	}{
+		{"missing stack name", Flags{}, true},
+		{"deployment file conflict", Flags{StackName: "s", DeploymentFile: "f", Template: "t"}, true},
+		{"valid", Flags{StackName: "s"}, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.flags.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/middleware/context_test.go
+++ b/cmd/middleware/context_test.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ArjenSchwarz/fog/config"
+)
+
+// TestContextMiddlewareExecute verifies that the middleware loads the config and
+// stores it on the context before calling the next handler.
+func TestContextMiddlewareExecute(t *testing.T) {
+	cfg := &config.Config{}
+	loaderCalled := false
+	mw := NewContextMiddleware(func() (*config.Config, error) {
+		loaderCalled = true
+		return cfg, nil
+	})
+
+	nextCalled := false
+	next := func(ctx context.Context) error {
+		nextCalled = true
+		got := ctx.Value(configKey)
+		if got != cfg {
+			t.Errorf("config not passed to context")
+		}
+		return nil
+	}
+
+	if err := mw.Execute(context.Background(), next); err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !loaderCalled {
+		t.Errorf("config loader was not called")
+	}
+	if !nextCalled {
+		t.Errorf("next handler was not called")
+	}
+}
+
+// TestContextMiddlewareExecuteError verifies that errors from the loader are
+// returned and that the next handler is not called.
+func TestContextMiddlewareExecuteError(t *testing.T) {
+	mw := NewContextMiddleware(func() (*config.Config, error) {
+		return nil, fmt.Errorf("load failure")
+	})
+
+	called := false
+	next := func(ctx context.Context) error {
+		called = true
+		return nil
+	}
+
+	err := mw.Execute(context.Background(), next)
+	if err == nil || !strings.Contains(err.Error(), "load failure") {
+		t.Fatalf("expected loader error, got %v", err)
+	}
+	if called {
+		t.Errorf("next should not be called on loader failure")
+	}
+}

--- a/cmd/registry/registry_test.go
+++ b/cmd/registry/registry_test.go
@@ -51,3 +51,31 @@ func TestRegistryBuildAllNilCommand(t *testing.T) {
 		t.Errorf("expected error when builder returns nil")
 	}
 }
+
+// TestRegistryBuildAllMultiple ensures that multiple registered commands are
+// added to the root command when BuildAll is called.
+func TestRegistryBuildAllMultiple(t *testing.T) {
+	root := &cobra.Command{Use: "root"}
+	registry := NewCommandRegistry(root)
+
+	err := registry.Register("one", stubBuilder{cmd: &cobra.Command{Use: "one"}})
+	if err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+	err = registry.Register("two", stubBuilder{cmd: &cobra.Command{Use: "two"}})
+	if err != nil {
+		t.Fatalf("unexpected register error: %v", err)
+	}
+
+	if err := registry.BuildAll(); err != nil {
+		t.Fatalf("unexpected build error: %v", err)
+	}
+
+	if len(root.Commands()) != 2 {
+		t.Fatalf("expected two commands to be registered")
+	}
+	uses := []string{root.Commands()[0].Use, root.Commands()[1].Use}
+	if !(uses[0] == "one" && uses[1] == "two" || uses[0] == "two" && uses[1] == "one") {
+		t.Errorf("commands not registered correctly: %v", uses)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration tests for the deploy command
- add tests for deploy flag validation
- test context middleware behavior
- broaden registry coverage

## Testing
- `go test ./... -cover`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_68436e0325048333b699fa251b4da0c0