### PR TITLE
[feature] service factory integration

### DIFF
--- a/cmd/commands/deploy/handler.go
+++ b/cmd/commands/deploy/handler.go
@@ -3,25 +3,76 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"strings"
+
+	"github.com/ArjenSchwarz/fog/cmd/services"
+	"github.com/ArjenSchwarz/fog/config"
 )
 
 // Handler implements the deploy command logic.
 type Handler struct {
-	flags *Flags
+	flags             *Flags
+	deploymentService services.DeploymentService
+	config            *config.Config
 }
 
 // NewHandler creates a new deploy command handler.
-func NewHandler(flags *Flags) *Handler {
-	return &Handler{flags: flags}
+func NewHandler(flags *Flags, deploymentService services.DeploymentService, config *config.Config) *Handler {
+	return &Handler{
+		flags:             flags,
+		deploymentService: deploymentService,
+		config:            config,
+	}
 }
 
-// Execute runs the deploy command.
-// The actual business logic will be implemented in a later refactor task.
+// Execute runs the deploy command using the deployment service.
 func (h *Handler) Execute(ctx context.Context) error {
-	// Retrieve command and args from context (for future use)
-	_ = ctx.Value("command")
-	_ = ctx.Value("args")
-	return fmt.Errorf("deploy handler not yet implemented - waiting for Task 2")
+	opts := services.DeploymentOptions{
+		StackName:      h.flags.StackName,
+		TemplateSource: h.flags.Template,
+		ParameterFiles: parseCommaSeparated(h.flags.Parameters),
+		TagFiles:       parseCommaSeparated(h.flags.Tags),
+		DefaultTags:    h.flags.DefaultTags,
+		Bucket:         h.flags.Bucket,
+		ChangesetName:  h.flags.ChangesetName,
+		DeploymentFile: h.flags.DeploymentFile,
+		DryRun:         h.flags.Dryrun,
+		NonInteractive: h.flags.NonInteractive,
+		CreateOnly:     h.flags.CreateChangeset,
+		DeployOnly:     h.flags.DeployChangeset,
+	}
+
+	plan, err := h.deploymentService.PrepareDeployment(ctx, opts)
+	if err != nil {
+		return fmt.Errorf("failed to prepare deployment: %w", err)
+	}
+
+	if err := h.deploymentService.ValidateDeployment(ctx, plan); err != nil {
+		return fmt.Errorf("deployment validation failed: %w", err)
+	}
+
+	changeset, err := h.deploymentService.CreateChangeset(ctx, plan)
+	if err != nil {
+		return fmt.Errorf("failed to create changeset: %w", err)
+	}
+
+	if opts.DryRun {
+		return nil
+	}
+
+	if opts.CreateOnly {
+		return nil
+	}
+
+	result, err := h.deploymentService.ExecuteDeployment(ctx, plan, changeset)
+	if err != nil {
+		return fmt.Errorf("deployment failed: %w", err)
+	}
+
+	if result.Success {
+		return nil
+	}
+	return fmt.Errorf("deployment completed with errors: %s", result.ErrorMessage)
 }
 
 // ValidateFlags validates the command flags using the Flags struct.
@@ -30,4 +81,19 @@ func (h *Handler) ValidateFlags() error {
 		return fmt.Errorf("no flags provided")
 	}
 	return h.flags.Validate()
+}
+
+// parseCommaSeparated splits a comma-separated string and trims whitespace.
+func parseCommaSeparated(input string) []string {
+	if input == "" {
+		return nil
+	}
+	parts := strings.Split(input, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			result = append(result, v)
+		}
+	}
+	return result
 }

--- a/cmd/commands/deploy/handler_test.go
+++ b/cmd/commands/deploy/handler_test.go
@@ -2,18 +2,38 @@ package deploy
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/ArjenSchwarz/fog/cmd/services"
+	"github.com/ArjenSchwarz/fog/config"
 )
+
+type mockHandlerDeploymentService struct{}
+
+func (m mockHandlerDeploymentService) PrepareDeployment(ctx context.Context, opts services.DeploymentOptions) (*services.DeploymentPlan, error) {
+	return &services.DeploymentPlan{}, nil
+}
+func (m mockHandlerDeploymentService) ValidateDeployment(ctx context.Context, plan *services.DeploymentPlan) error {
+	return nil
+}
+func (m mockHandlerDeploymentService) CreateChangeset(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, error) {
+	return nil, fmt.Errorf("changeset logic not implemented")
+}
+func (m mockHandlerDeploymentService) ExecuteDeployment(ctx context.Context, plan *services.DeploymentPlan, cs *services.ChangesetResult) (*services.DeploymentResult, error) {
+	return &services.DeploymentResult{Success: true}, nil
+}
 
 // TestValidateFlags verifies that ValidateFlags returns any errors from the Flags
 // validation logic.
 func TestValidateFlags(t *testing.T) {
-	h := NewHandler(&Flags{StackName: "test"})
+	h := NewHandler(&Flags{StackName: "test"}, mockHandlerDeploymentService{}, &config.Config{})
 	if err := h.ValidateFlags(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	h = NewHandler(&Flags{})
+	h = NewHandler(&Flags{}, mockHandlerDeploymentService{}, &config.Config{})
 	if err := h.ValidateFlags(); err == nil {
 		t.Fatalf("expected validation error when stack name missing")
 	}
@@ -21,9 +41,9 @@ func TestValidateFlags(t *testing.T) {
 
 // TestExecute verifies that Execute currently returns the not implemented error.
 func TestExecute(t *testing.T) {
-	h := NewHandler(&Flags{StackName: "test"})
+	h := NewHandler(&Flags{StackName: "test"}, mockHandlerDeploymentService{}, &config.Config{})
 	err := h.Execute(context.Background())
-	if err == nil {
-		t.Fatalf("expected error")
+	if err == nil || !strings.Contains(err.Error(), "failed to create changeset") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ArjenSchwarz/fog/cmd/commands/deploy"
 	"github.com/ArjenSchwarz/fog/cmd/registry"
+	servicesfactory "github.com/ArjenSchwarz/fog/cmd/services/factory"
 	"github.com/ArjenSchwarz/fog/config"
 	format "github.com/ArjenSchwarz/go-output"
 	"github.com/spf13/cobra"
@@ -62,8 +63,12 @@ func init() {
 	// Create command registry
 	commandRegistry := registry.NewCommandRegistry(rootCmd)
 
+	// Instantiate service factory
+	awsCfg := config.AWSConfig{}
+	factory := servicesfactory.NewServiceFactory(settings, &awsCfg)
+
 	// Register commands
-	if err := commandRegistry.Register("deploy", deploy.NewCommandBuilder()); err != nil {
+	if err := commandRegistry.Register("deploy", deploy.NewCommandBuilder(factory)); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/services/factory/factory.go
+++ b/cmd/services/factory/factory.go
@@ -9,8 +9,6 @@ import (
 
 // ServiceFactory creates service instances with proper dependencies
 // and provides access to configuration objects.
-// ServiceFactory creates service instances with proper dependencies
-// and provides access to configuration objects.
 type ServiceFactory struct {
 	config    *config.Config
 	awsConfig *config.AWSConfig

--- a/cmd/services/factory/factory.go
+++ b/cmd/services/factory/factory.go
@@ -1,0 +1,57 @@
+package factory
+
+import (
+	"github.com/ArjenSchwarz/fog/cmd/services"
+	"github.com/ArjenSchwarz/fog/cmd/services/aws"
+	"github.com/ArjenSchwarz/fog/cmd/services/deployment"
+	"github.com/ArjenSchwarz/fog/config"
+)
+
+// ServiceFactory creates service instances with proper dependencies
+// and provides access to configuration objects.
+// ServiceFactory creates service instances with proper dependencies
+// and provides access to configuration objects.
+type ServiceFactory struct {
+	config    *config.Config
+	awsConfig *config.AWSConfig
+}
+
+// NewServiceFactory creates a new service factory.
+func NewServiceFactory(cfg *config.Config, awsCfg *config.AWSConfig) *ServiceFactory {
+	return &ServiceFactory{config: cfg, awsConfig: awsCfg}
+}
+
+// AppConfig returns the application config.
+func (f *ServiceFactory) AppConfig() *config.Config { return f.config }
+
+// AWSConfig returns the AWS configuration.
+func (f *ServiceFactory) AWSConfig() *config.AWSConfig { return f.awsConfig }
+
+// CreateDeploymentService creates a deployment service with dependencies.
+func (f *ServiceFactory) CreateDeploymentService() services.DeploymentService {
+	cfnClient := aws.NewCloudFormationClient(*f.awsConfig)
+	s3Client := aws.NewS3Client(*f.awsConfig)
+
+	templateService := deployment.NewTemplateService(s3Client)
+	parameterService := deployment.NewParameterService()
+	tagService := deployment.NewTagService()
+
+	return deployment.NewService(
+		templateService,
+		parameterService,
+		tagService,
+		cfnClient,
+		s3Client,
+		f.config,
+	)
+}
+
+// CreateDriftService creates a drift detection service.
+func (f *ServiceFactory) CreateDriftService() services.DriftService {
+	return nil
+}
+
+// CreateStackService creates a stack operations service.
+func (f *ServiceFactory) CreateStackService() services.StackService {
+	return nil
+}


### PR DESCRIPTION
## Summary
- add service factory implementation
- update deploy command handler to use service layer
- inject deployment service via command builder
- wire service factory in root command setup
- update tests for new interfaces

## Testing
- `go test ./... -v`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_6843ffdad9ec8333b32cde6bc2510014