### PR TITLE
[feature] add error and recovery middleware

### DIFF
--- a/cmd/middleware/error_handler.go
+++ b/cmd/middleware/error_handler.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/ArjenSchwarz/fog/cmd/errors"
+	"github.com/ArjenSchwarz/fog/cmd/registry"
+	"github.com/ArjenSchwarz/fog/cmd/ui"
+)
+
+// ErrorHandlingMiddleware provides centralized error handling.
+type ErrorHandlingMiddleware struct {
+	formatter errors.ErrorFormatter
+	ui        ui.OutputHandler
+	verbose   bool
+}
+
+// NewErrorHandlingMiddleware creates a new error handling middleware.
+func NewErrorHandlingMiddleware(formatter errors.ErrorFormatter, ui ui.OutputHandler, verbose bool) *ErrorHandlingMiddleware {
+	return &ErrorHandlingMiddleware{
+		formatter: formatter,
+		ui:        ui,
+		verbose:   verbose,
+	}
+}
+
+// Execute handles errors from command execution.
+func (m *ErrorHandlingMiddleware) Execute(ctx context.Context, next func(context.Context) error) error {
+	err := next(ctx)
+	if err == nil {
+		return nil
+	}
+
+	// Convert to FogError if needed.
+	var fogErr errors.FogError
+	if fe, ok := err.(errors.FogError); ok {
+		fogErr = fe
+	} else {
+		errorCtx := errors.GetErrorContext(ctx)
+		fogErr = errors.WrapError(errorCtx, err, errors.ErrUnknown, "Unknown error occurred")
+	}
+
+	// Format and display the error.
+	m.displayError(fogErr)
+
+	// Return the original error so exit codes propagate.
+	return err
+}
+
+// displayError formats and displays an error.
+func (m *ErrorHandlingMiddleware) displayError(err errors.FogError) {
+	if multiErr, ok := err.(*errors.MultiError); ok {
+		m.ui.Error(m.formatter.FormatMultiError(multiErr))
+		return
+	}
+
+	formatted := m.formatter.FormatError(err)
+
+	switch err.Severity() {
+	case errors.SeverityCritical, errors.SeverityHigh:
+		m.ui.Error(formatted)
+	case errors.SeverityMedium:
+		m.ui.Warning(formatted)
+	case errors.SeverityLow:
+		m.ui.Info(formatted)
+	default:
+		m.ui.Error(formatted)
+	}
+
+	if m.verbose && err.StackTrace() != nil {
+		m.ui.Debug("Stack trace:")
+		for _, frame := range err.StackTrace() {
+			m.ui.Debug("  " + frame)
+		}
+	}
+}
+
+var _ registry.Middleware = (*ErrorHandlingMiddleware)(nil)

--- a/cmd/middleware/error_handler.go
+++ b/cmd/middleware/error_handler.go
@@ -12,15 +12,13 @@ import (
 type ErrorHandlingMiddleware struct {
 	formatter errors.ErrorFormatter
 	ui        ui.OutputHandler
-	verbose   bool
 }
 
 // NewErrorHandlingMiddleware creates a new error handling middleware.
-func NewErrorHandlingMiddleware(formatter errors.ErrorFormatter, ui ui.OutputHandler, verbose bool) *ErrorHandlingMiddleware {
+func NewErrorHandlingMiddleware(formatter errors.ErrorFormatter, ui ui.OutputHandler) *ErrorHandlingMiddleware {
 	return &ErrorHandlingMiddleware{
 		formatter: formatter,
 		ui:        ui,
-		verbose:   verbose,
 	}
 }
 
@@ -67,7 +65,7 @@ func (m *ErrorHandlingMiddleware) displayError(err errors.FogError) {
 		m.ui.Error(formatted)
 	}
 
-	if m.verbose && err.StackTrace() != nil {
+	if m.ui.GetVerbose() && err.StackTrace() != nil {
 		m.ui.Debug("Stack trace:")
 		for _, frame := range err.StackTrace() {
 			m.ui.Debug("  " + frame)

--- a/cmd/middleware/error_handler_test.go
+++ b/cmd/middleware/error_handler_test.go
@@ -64,7 +64,7 @@ func (s *stubUI) GetVerbose() bool                          { return s.verbose }
 func TestErrorHandlingMiddleware_ConvertsGenericError(t *testing.T) {
 	formatter := &stubFormatter{}
 	ui := &stubUI{}
-	mw := NewErrorHandlingMiddleware(formatter, ui, false)
+	mw := NewErrorHandlingMiddleware(formatter, ui)
 
 	next := func(context.Context) error {
 		return errors.New("boom")
@@ -107,7 +107,7 @@ func TestRecoveryMiddleware_RecoversPanic(t *testing.T) {
 func TestErrorHandlingMiddleware_FormatterIntegration(t *testing.T) {
 	formatter := &stubFormatter{}
 	ui := &stubUI{}
-	mw := NewErrorHandlingMiddleware(formatter, ui, false)
+	mw := NewErrorHandlingMiddleware(formatter, ui)
 
 	// multi error should use FormatMultiError
 	e1 := ferr.NewError(ferr.ErrUnknown, "one")

--- a/cmd/middleware/error_handler_test.go
+++ b/cmd/middleware/error_handler_test.go
@@ -1,0 +1,126 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
+	"github.com/ArjenSchwarz/fog/cmd/ui"
+)
+
+// stubFormatter is a simple formatter used for tests.
+type stubFormatter struct {
+	formatted      string
+	multiFormatted string
+	lastErr        ferr.FogError
+}
+
+func (s *stubFormatter) FormatError(err ferr.FogError) string {
+	s.lastErr = err
+	s.formatted = "formatted:" + err.Message()
+	return s.formatted
+}
+func (s *stubFormatter) FormatMultiError(err *ferr.MultiError) string {
+	s.multiFormatted = "multi"
+	return s.multiFormatted
+}
+func (s *stubFormatter) FormatValidationErrors([]ferr.FogError) string { return "" }
+
+// stubUI implements ui.OutputHandler for testing.
+type stubUI struct {
+	errors   []string
+	warnings []string
+	infos    []string
+	debugs   []string
+	verbose  bool
+}
+
+func (s *stubUI) Success(string)     {}
+func (s *stubUI) Info(msg string)    { s.infos = append(s.infos, msg) }
+func (s *stubUI) Warning(msg string) { s.warnings = append(s.warnings, msg) }
+func (s *stubUI) Error(msg string)   { s.errors = append(s.errors, msg) }
+func (s *stubUI) Debug(msg string) {
+	if s.verbose {
+		s.debugs = append(s.debugs, msg)
+	}
+}
+func (s *stubUI) Table(interface{}, ui.TableOptions) error  { return nil }
+func (s *stubUI) JSON(interface{}) error                    { return nil }
+func (s *stubUI) StartProgress(string) ui.ProgressIndicator { return nil }
+func (s *stubUI) SetStatus(string)                          {}
+func (s *stubUI) Confirm(string) bool                       { return false }
+func (s *stubUI) ConfirmWithDefault(string, bool) bool      { return false }
+func (s *stubUI) SetVerbose(v bool)                         { s.verbose = v }
+func (s *stubUI) SetQuiet(bool)                             {}
+func (s *stubUI) SetOutputFormat(ui.OutputFormat)           {}
+func (s *stubUI) GetWriter() io.Writer                      { return nil }
+func (s *stubUI) GetErrorWriter() io.Writer                 { return nil }
+func (s *stubUI) GetVerbose() bool                          { return s.verbose }
+
+// Ensure we import io
+
+func TestErrorHandlingMiddleware_ConvertsGenericError(t *testing.T) {
+	formatter := &stubFormatter{}
+	ui := &stubUI{}
+	mw := NewErrorHandlingMiddleware(formatter, ui, false)
+
+	next := func(context.Context) error {
+		return errors.New("boom")
+	}
+
+	err := mw.Execute(context.Background(), next)
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected original error returned")
+	}
+	if formatter.lastErr == nil {
+		t.Fatalf("formatter not called")
+	}
+	if len(ui.infos) == 0 || ui.infos[0] != formatter.formatted {
+		t.Fatalf("formatted error not output")
+	}
+}
+
+func TestRecoveryMiddleware_RecoversPanic(t *testing.T) {
+	ui := &stubUI{verbose: true}
+	mw := NewRecoveryMiddleware(ui)
+
+	err := mw.Execute(context.Background(), func(context.Context) error {
+		panic("kaboom")
+	})
+
+	if err == nil {
+		t.Fatalf("expected error from panic")
+	}
+	if fe, ok := err.(ferr.FogError); !ok || fe.Code() != ferr.ErrInternal {
+		t.Fatalf("unexpected error type: %#v", err)
+	}
+	if len(ui.errors) == 0 {
+		t.Fatalf("error message not displayed")
+	}
+	if len(ui.debugs) == 0 {
+		t.Fatalf("debug output expected in verbose mode")
+	}
+}
+
+func TestErrorHandlingMiddleware_FormatterIntegration(t *testing.T) {
+	formatter := &stubFormatter{}
+	ui := &stubUI{}
+	mw := NewErrorHandlingMiddleware(formatter, ui, false)
+
+	// multi error should use FormatMultiError
+	e1 := ferr.NewError(ferr.ErrUnknown, "one")
+	e2 := ferr.NewError(ferr.ErrUnknown, "two")
+	multi := ferr.NewMultiError("ctx", []ferr.FogError{e1, e2})
+
+	next := func(context.Context) error { return multi }
+	_ = mw.Execute(context.Background(), next)
+
+	if formatter.multiFormatted == "" {
+		t.Fatalf("multi error not formatted")
+	}
+	if len(ui.errors) == 0 || ui.errors[0] != formatter.multiFormatted {
+		t.Fatalf("multi error not output")
+	}
+}

--- a/cmd/middleware/recovery.go
+++ b/cmd/middleware/recovery.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ArjenSchwarz/fog/cmd/errors"
+	"github.com/ArjenSchwarz/fog/cmd/registry"
+	"github.com/ArjenSchwarz/fog/cmd/ui"
+)
+
+// RecoveryMiddleware handles panics and converts them to errors.
+type RecoveryMiddleware struct {
+	ui ui.OutputHandler
+}
+
+// NewRecoveryMiddleware creates a new recovery middleware.
+func NewRecoveryMiddleware(ui ui.OutputHandler) *RecoveryMiddleware {
+	return &RecoveryMiddleware{ui: ui}
+}
+
+// Execute handles panic recovery.
+func (m *RecoveryMiddleware) Execute(ctx context.Context, next func(context.Context) error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			errorCtx := errors.GetErrorContext(ctx)
+			panicErr := func() errors.FogError {
+				be := errors.ContextualError(
+					errorCtx,
+					errors.ErrInternal,
+					fmt.Sprintf("Internal error (panic): %v", r),
+				).(*errors.BaseError)
+				return be.WithStackTrace()
+			}()
+
+			m.ui.Error(fmt.Sprintf("Internal error occurred: %v", r))
+			if m.ui.GetVerbose() {
+				m.ui.Debug("This is likely a bug. Please report it with the following information:")
+				for _, frame := range panicErr.StackTrace() {
+					m.ui.Debug("  " + frame)
+				}
+			}
+
+			err = panicErr
+		}
+	}()
+
+	return next(ctx)
+}
+
+var _ registry.Middleware = (*RecoveryMiddleware)(nil)

--- a/cmd/ui/interfaces.go
+++ b/cmd/ui/interfaces.go
@@ -1,0 +1,239 @@
+package ui
+
+import (
+	"io"
+	"time"
+)
+
+// OutputHandler manages all output operations
+// This is a simplified version of the interface described in the documentation.
+type OutputHandler interface {
+	Success(message string)
+	Info(message string)
+	Warning(message string)
+	Error(message string)
+	Debug(message string)
+
+	Table(data interface{}, options TableOptions) error
+	JSON(data interface{}) error
+
+	StartProgress(message string) ProgressIndicator
+	SetStatus(message string)
+
+	Confirm(message string) bool
+	ConfirmWithDefault(message string, defaultValue bool) bool
+
+	SetVerbose(verbose bool)
+	SetQuiet(quiet bool)
+	SetOutputFormat(format OutputFormat)
+
+	GetWriter() io.Writer
+	GetErrorWriter() io.Writer
+
+	// GetVerbose returns whether verbose mode is enabled
+	GetVerbose() bool
+}
+
+// ProgressIndicator represents a progress indicator
+// used for long running operations.
+type ProgressIndicator interface {
+	Update(message string)
+	Success(message string)
+	Error(message string)
+	Stop()
+}
+
+// TableOptions configures table output
+// for various command results.
+type TableOptions struct {
+	Title     string
+	Headers   []string
+	MaxWidth  int
+	Style     TableStyle
+	SortBy    string
+	ShowIndex bool
+}
+
+// TableStyle defines table visual styles.
+type TableStyle int
+
+const (
+	TableStyleDefault TableStyle = iota
+	TableStyleMinimal
+	TableStyleBordered
+	TableStyleCompact
+)
+
+// OutputFormat defines the output format
+// for structured command results.
+type OutputFormat int
+
+const (
+	FormatTable OutputFormat = iota
+	FormatJSON
+	FormatCSV
+	FormatYAML
+	FormatText
+)
+
+// Theme defines UI styling. Only included here
+// for completeness; implementations may ignore it.
+type Theme interface {
+	Success() string
+	Info() string
+	Warning() string
+	Error() string
+	Debug() string
+	Emphasis() string
+	Muted() string
+
+	ProgressSpinner() string
+	ProgressSuccess() string
+	ProgressError() string
+
+	TableHeader() string
+	TableBorder() string
+	TableData() string
+}
+
+// Formatter formats specific output structures.
+type Formatter interface {
+	FormatDeploymentInfo(info DeploymentInfo) string
+	FormatChangeset(changeset ChangesetInfo) string
+	FormatDriftResult(result DriftResult) string
+	FormatStackInfo(stack StackInfo) string
+}
+
+// ValidationDisplayer handles validation message display.
+type ValidationDisplayer interface {
+	ShowValidationErrors(errors []ValidationError)
+	ShowValidationWarnings(warnings []ValidationWarning)
+	ShowValidationSummary(summary ValidationSummary)
+}
+
+// Various data structures referenced by Formatter and ValidationDisplayer.
+type DeploymentInfo struct {
+	StackName    string
+	Region       string
+	Account      string
+	IsNew        bool
+	DryRun       bool
+	TemplateInfo TemplateInfo
+}
+
+type TemplateInfo struct {
+	Path  string
+	Size  int64
+	S3URL string
+	Hash  string
+}
+
+type ChangesetInfo struct {
+	Name        string
+	Status      string
+	Changes     []ChangeInfo
+	Summary     ChangeSummary
+	DangerLevel DangerLevel
+}
+
+type ChangeInfo struct {
+	Action       string
+	ResourceType string
+	LogicalID    string
+	PhysicalID   string
+	Replacement  string
+	Details      []ChangeDetail
+}
+
+type ChangeDetail struct {
+	Property   string
+	OldValue   interface{}
+	NewValue   interface{}
+	ChangeType string
+}
+
+type ChangeSummary struct {
+	TotalChanges  int
+	Additions     int
+	Modifications int
+	Deletions     int
+	Replacements  int
+}
+
+type DangerLevel int
+
+const (
+	DangerLow DangerLevel = iota
+	DangerMedium
+	DangerHigh
+	DangerCritical
+)
+
+type DriftResult struct {
+	StackName      string
+	DriftStatus    string
+	TotalResources int
+	DriftedCount   int
+	Resources      []DriftedResource
+}
+
+type DriftedResource struct {
+	LogicalID    string
+	PhysicalID   string
+	ResourceType string
+	DriftStatus  string
+	Properties   []PropertyDrift
+}
+
+type PropertyDrift struct {
+	PropertyPath string
+	Expected     interface{}
+	Actual       interface{}
+	DriftType    string
+}
+
+type StackInfo struct {
+	Name       string
+	Status     string
+	CreatedAt  time.Time
+	UpdatedAt  *time.Time
+	Parameters []Parameter
+	Outputs    []Output
+	Tags       []Tag
+}
+
+// Import time after using above struct referencing time
+type Parameter struct {
+	Key   string
+	Value string
+}
+
+type Output struct {
+	Key         string
+	Value       string
+	Description string
+	ExportName  string
+}
+
+type Tag struct {
+	Key   string
+	Value string
+}
+
+type ValidationError struct {
+	Field   string
+	Message string
+	Code    string
+}
+
+type ValidationWarning struct {
+	Field   string
+	Message string
+	Code    string
+}
+
+type ValidationSummary struct {
+	ErrorCount   int
+	WarningCount int
+	InfoCount    int
+}


### PR DESCRIPTION
## Summary
- implement ErrorHandlingMiddleware and RecoveryMiddleware
- provide basic ui interfaces
- test error handling and panic recovery

## Testing
- `go test ./... -v`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6844371a2ec083338d32c927f8ca3138