### PR TITLE
[refactor] return FogError types from deployment services

### DIFF
--- a/cmd/commands/deploy/command_integration_test.go
+++ b/cmd/commands/deploy/command_integration_test.go
@@ -2,10 +2,10 @@ package deploy
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"testing"
 
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
 	"github.com/ArjenSchwarz/fog/cmd/services"
 	"github.com/ArjenSchwarz/fog/config"
 	"github.com/spf13/cobra"
@@ -13,16 +13,16 @@ import (
 
 type integrationDeploymentService struct{}
 
-func (m integrationDeploymentService) PrepareDeployment(ctx context.Context, opts services.DeploymentOptions) (*services.DeploymentPlan, error) {
+func (m integrationDeploymentService) PrepareDeployment(ctx context.Context, opts services.DeploymentOptions) (*services.DeploymentPlan, ferr.FogError) {
 	return &services.DeploymentPlan{}, nil
 }
-func (m integrationDeploymentService) ValidateDeployment(ctx context.Context, plan *services.DeploymentPlan) error {
+func (m integrationDeploymentService) ValidateDeployment(ctx context.Context, plan *services.DeploymentPlan) ferr.FogError {
 	return nil
 }
-func (m integrationDeploymentService) CreateChangeset(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, error) {
-	return nil, fmt.Errorf("changeset logic not implemented")
+func (m integrationDeploymentService) CreateChangeset(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, ferr.FogError) {
+	return nil, ferr.NewError(ferr.ErrNotImplemented, "changeset logic not implemented")
 }
-func (m integrationDeploymentService) ExecuteDeployment(ctx context.Context, plan *services.DeploymentPlan, cs *services.ChangesetResult) (*services.DeploymentResult, error) {
+func (m integrationDeploymentService) ExecuteDeployment(ctx context.Context, plan *services.DeploymentPlan, cs *services.ChangesetResult) (*services.DeploymentResult, ferr.FogError) {
 	return &services.DeploymentResult{Success: true}, nil
 }
 

--- a/cmd/commands/deploy/handler_test.go
+++ b/cmd/commands/deploy/handler_test.go
@@ -2,7 +2,6 @@ package deploy
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
@@ -12,16 +11,16 @@ import (
 
 type mockHandlerDeploymentService struct{}
 
-func (m mockHandlerDeploymentService) PrepareDeployment(ctx context.Context, opts services.DeploymentOptions) (*services.DeploymentPlan, error) {
+func (m mockHandlerDeploymentService) PrepareDeployment(ctx context.Context, opts services.DeploymentOptions) (*services.DeploymentPlan, ferr.FogError) {
 	return &services.DeploymentPlan{}, nil
 }
-func (m mockHandlerDeploymentService) ValidateDeployment(ctx context.Context, plan *services.DeploymentPlan) error {
+func (m mockHandlerDeploymentService) ValidateDeployment(ctx context.Context, plan *services.DeploymentPlan) ferr.FogError {
 	return nil
 }
-func (m mockHandlerDeploymentService) CreateChangeset(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, error) {
-	return nil, fmt.Errorf("changeset logic not implemented")
+func (m mockHandlerDeploymentService) CreateChangeset(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, ferr.FogError) {
+	return nil, ferr.NewError(ferr.ErrNotImplemented, "changeset logic not implemented")
 }
-func (m mockHandlerDeploymentService) ExecuteDeployment(ctx context.Context, plan *services.DeploymentPlan, cs *services.ChangesetResult) (*services.DeploymentResult, error) {
+func (m mockHandlerDeploymentService) ExecuteDeployment(ctx context.Context, plan *services.DeploymentPlan, cs *services.ChangesetResult) (*services.DeploymentResult, ferr.FogError) {
 	return &services.DeploymentResult{Success: true}, nil
 }
 

--- a/cmd/services/deployment/changeset.go
+++ b/cmd/services/deployment/changeset.go
@@ -2,14 +2,14 @@ package deployment
 
 import (
 	"context"
-	"fmt"
 
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
 	"github.com/ArjenSchwarz/fog/cmd/services"
 )
 
 // createChangeSet is a helper used by Service.CreateChangeset.
-func (s *Service) createChangeSet(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, error) {
-	_ = ctx
+func (s *Service) createChangeSet(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, ferr.FogError) {
 	_ = plan
-	return nil, fmt.Errorf("changeset logic not implemented")
+	errorCtx := ferr.GetErrorContext(ctx)
+	return nil, ferr.ContextualError(errorCtx, ferr.ErrNotImplemented, "changeset logic not implemented")
 }

--- a/cmd/services/deployment/parameters.go
+++ b/cmd/services/deployment/parameters.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
 	"github.com/ArjenSchwarz/fog/cmd/services"
 	cfnTypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 )
@@ -14,14 +15,14 @@ type ParameterService struct{}
 func NewParameterService() *ParameterService { return &ParameterService{} }
 
 // LoadParameters loads parameters from files. Placeholder implementation.
-func (p *ParameterService) LoadParameters(ctx context.Context, parameterFiles []string) ([]cfnTypes.Parameter, error) {
+func (p *ParameterService) LoadParameters(ctx context.Context, parameterFiles []string) ([]cfnTypes.Parameter, ferr.FogError) {
 	_ = ctx
 	// Real implementation would read parameter files
 	return []cfnTypes.Parameter{}, nil
 }
 
 // ValidateParameters validates parameter values against a template. Placeholder.
-func (p *ParameterService) ValidateParameters(ctx context.Context, parameters []cfnTypes.Parameter, template *services.Template) error {
+func (p *ParameterService) ValidateParameters(ctx context.Context, parameters []cfnTypes.Parameter, template *services.Template) ferr.FogError {
 	_ = ctx
 	_ = template
 	_ = parameters

--- a/cmd/services/deployment/service.go
+++ b/cmd/services/deployment/service.go
@@ -2,8 +2,8 @@ package deployment
 
 import (
 	"context"
-	"fmt"
 
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
 	"github.com/ArjenSchwarz/fog/cmd/services"
 	"github.com/ArjenSchwarz/fog/config"
 )
@@ -32,7 +32,7 @@ func NewService(tmpl services.TemplateService, params services.ParameterService,
 
 // PrepareDeployment builds a DeploymentPlan from the given options.
 // This placeholder only fills a few fields and performs no AWS calls.
-func (s *Service) PrepareDeployment(ctx context.Context, opts services.DeploymentOptions) (*services.DeploymentPlan, error) {
+func (s *Service) PrepareDeployment(ctx context.Context, opts services.DeploymentOptions) (*services.DeploymentPlan, ferr.FogError) {
 	plan := &services.DeploymentPlan{
 		StackName:     opts.StackName,
 		Options:       opts,
@@ -65,7 +65,7 @@ func (s *Service) PrepareDeployment(ctx context.Context, opts services.Deploymen
 }
 
 // ValidateDeployment performs basic validation of the deployment plan.
-func (s *Service) ValidateDeployment(ctx context.Context, plan *services.DeploymentPlan) error {
+func (s *Service) ValidateDeployment(ctx context.Context, plan *services.DeploymentPlan) ferr.FogError {
 	if err := s.templateService.ValidateTemplate(ctx, plan.Template); err != nil {
 		return err
 	}
@@ -83,12 +83,13 @@ func (s *Service) ValidateDeployment(ctx context.Context, plan *services.Deploym
 
 // CreateChangeset creates a CloudFormation changeset.
 // Placeholder implementation returning a not implemented error.
-func (s *Service) CreateChangeset(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, error) {
+func (s *Service) CreateChangeset(ctx context.Context, plan *services.DeploymentPlan) (*services.ChangesetResult, ferr.FogError) {
 	return s.createChangeSet(ctx, plan)
 }
 
 // ExecuteDeployment executes the previously created changeset.
 // Placeholder implementation returning a not implemented error.
-func (s *Service) ExecuteDeployment(ctx context.Context, plan *services.DeploymentPlan, changeset *services.ChangesetResult) (*services.DeploymentResult, error) {
-	return nil, fmt.Errorf("deployment execution not implemented")
+func (s *Service) ExecuteDeployment(ctx context.Context, plan *services.DeploymentPlan, changeset *services.ChangesetResult) (*services.DeploymentResult, ferr.FogError) {
+	errorCtx := ferr.GetErrorContext(ctx)
+	return nil, ferr.ContextualError(errorCtx, ferr.ErrNotImplemented, "deployment execution not implemented")
 }

--- a/cmd/services/deployment/tags.go
+++ b/cmd/services/deployment/tags.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
 	cfnTypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 )
 
@@ -13,7 +14,7 @@ type TagService struct{}
 func NewTagService() *TagService { return &TagService{} }
 
 // LoadTags loads tags from files. Placeholder implementation.
-func (t *TagService) LoadTags(ctx context.Context, tagFiles []string, defaults map[string]string) ([]cfnTypes.Tag, error) {
+func (t *TagService) LoadTags(ctx context.Context, tagFiles []string, defaults map[string]string) ([]cfnTypes.Tag, ferr.FogError) {
 	_ = ctx
 	_ = tagFiles
 	// Real implementation would merge defaults and file contents
@@ -28,7 +29,7 @@ func (t *TagService) LoadTags(ctx context.Context, tagFiles []string, defaults m
 }
 
 // ValidateTags validates the provided tags. Placeholder implementation.
-func (t *TagService) ValidateTags(ctx context.Context, tags []cfnTypes.Tag) error {
+func (t *TagService) ValidateTags(ctx context.Context, tags []cfnTypes.Tag) ferr.FogError {
 	_ = ctx
 	_ = tags
 	return nil

--- a/cmd/services/deployment/template.go
+++ b/cmd/services/deployment/template.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
 	"github.com/ArjenSchwarz/fog/cmd/services"
 	"github.com/ArjenSchwarz/fog/lib"
 )
@@ -20,24 +21,26 @@ func NewTemplateService(s3 services.S3Client) *TemplateService {
 }
 
 // LoadTemplate loads a template from disk using lib.ReadTemplate.
-func (ts *TemplateService) LoadTemplate(ctx context.Context, templatePath string) (*services.Template, error) {
+func (ts *TemplateService) LoadTemplate(ctx context.Context, templatePath string) (*services.Template, ferr.FogError) {
 	content, path, err := lib.ReadTemplate(&templatePath)
 	if err != nil {
-		return nil, err
+		errorCtx := ferr.GetErrorContext(ctx)
+		return nil, ferr.ContextualError(errorCtx, ferr.ErrTemplateNotFound, err.Error())
 	}
 	return &services.Template{Content: content, LocalPath: path}, nil
 }
 
 // ValidateTemplate performs basic template validation.
-func (ts *TemplateService) ValidateTemplate(ctx context.Context, template *services.Template) error {
+func (ts *TemplateService) ValidateTemplate(ctx context.Context, template *services.Template) ferr.FogError {
 	if template.Content == "" {
-		return fmt.Errorf("template content is empty")
+		errorCtx := ferr.GetErrorContext(ctx)
+		return ferr.ContextualError(errorCtx, ferr.ErrTemplateInvalid, "template content is empty")
 	}
 	return nil
 }
 
 // UploadTemplate uploads a template to S3. Only placeholder logic implemented.
-func (ts *TemplateService) UploadTemplate(ctx context.Context, template *services.Template, bucket string) (*services.TemplateReference, error) {
+func (ts *TemplateService) UploadTemplate(ctx context.Context, template *services.Template, bucket string) (*services.TemplateReference, ferr.FogError) {
 	key := filepath.Base(template.LocalPath)
 	template.S3URL = fmt.Sprintf("s3://%s/%s", bucket, key)
 	return &services.TemplateReference{URL: template.S3URL, Bucket: bucket, Key: key, Version: ""}, nil

--- a/cmd/services/deployment/validation.go
+++ b/cmd/services/deployment/validation.go
@@ -3,12 +3,13 @@ package deployment
 import (
 	"context"
 
+	ferr "github.com/ArjenSchwarz/fog/cmd/errors"
 	"github.com/ArjenSchwarz/fog/cmd/services"
 )
 
 // validateStackState checks if a stack can be updated. Placeholder implementation.
-func (s *Service) validateStackState(ctx context.Context, plan *services.DeploymentPlan) error {
-	_ = ctx
+func (s *Service) validateStackState(ctx context.Context, plan *services.DeploymentPlan) ferr.FogError {
 	_ = plan
+	_ = ctx
 	return nil
 }

--- a/cmd/services/interfaces.go
+++ b/cmd/services/interfaces.go
@@ -3,6 +3,7 @@ package services
 import (
 	"context"
 
+	"github.com/ArjenSchwarz/fog/cmd/errors"
 	"github.com/ArjenSchwarz/fog/config"
 	"github.com/ArjenSchwarz/fog/lib"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
@@ -13,10 +14,10 @@ import (
 // DeploymentService handles stack deployment operations
 // Methods mirror the high level deployment steps.
 type DeploymentService interface {
-	PrepareDeployment(ctx context.Context, opts DeploymentOptions) (*DeploymentPlan, error)
-	ValidateDeployment(ctx context.Context, plan *DeploymentPlan) error
-	CreateChangeset(ctx context.Context, plan *DeploymentPlan) (*ChangesetResult, error)
-	ExecuteDeployment(ctx context.Context, plan *DeploymentPlan, changeset *ChangesetResult) (*DeploymentResult, error)
+	PrepareDeployment(ctx context.Context, opts DeploymentOptions) (*DeploymentPlan, errors.FogError)
+	ValidateDeployment(ctx context.Context, plan *DeploymentPlan) errors.FogError
+	CreateChangeset(ctx context.Context, plan *DeploymentPlan) (*ChangesetResult, errors.FogError)
+	ExecuteDeployment(ctx context.Context, plan *DeploymentPlan, changeset *ChangesetResult) (*DeploymentResult, errors.FogError)
 }
 
 // DriftService handles drift detection operations
@@ -37,21 +38,21 @@ type StackService interface {
 // TemplateService handles template operations
 // It abstracts loading, validating and uploading templates.
 type TemplateService interface {
-	LoadTemplate(ctx context.Context, templatePath string) (*Template, error)
-	ValidateTemplate(ctx context.Context, template *Template) error
-	UploadTemplate(ctx context.Context, template *Template, bucket string) (*TemplateReference, error)
+	LoadTemplate(ctx context.Context, templatePath string) (*Template, errors.FogError)
+	ValidateTemplate(ctx context.Context, template *Template) errors.FogError
+	UploadTemplate(ctx context.Context, template *Template, bucket string) (*TemplateReference, errors.FogError)
 }
 
 // ParameterService handles parameter operations.
 type ParameterService interface {
-	LoadParameters(ctx context.Context, parameterFiles []string) ([]cfnTypes.Parameter, error)
-	ValidateParameters(ctx context.Context, parameters []cfnTypes.Parameter, template *Template) error
+	LoadParameters(ctx context.Context, parameterFiles []string) ([]cfnTypes.Parameter, errors.FogError)
+	ValidateParameters(ctx context.Context, parameters []cfnTypes.Parameter, template *Template) errors.FogError
 }
 
 // TagService handles tag operations.
 type TagService interface {
-	LoadTags(ctx context.Context, tagFiles []string, defaults map[string]string) ([]cfnTypes.Tag, error)
-	ValidateTags(ctx context.Context, tags []cfnTypes.Tag) error
+	LoadTags(ctx context.Context, tagFiles []string, defaults map[string]string) ([]cfnTypes.Tag, errors.FogError)
+	ValidateTags(ctx context.Context, tags []cfnTypes.Tag) errors.FogError
 }
 
 // CloudFormationClient abstracts AWS CloudFormation operations used by services.


### PR DESCRIPTION
## Summary
- return `errors.FogError` from deployment service interfaces
- propagate FogError values through deployment service implementations
- add contextual error information for templates, changesets, and deployments
- update tests to use new FogError signatures

## Testing
- `go test ./... -v`
- `golangci-lint run ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844487317c883338b10213e06a56a86