### PR TITLE
[doc] document FogError system

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,14 @@ drift:
 
 There is a lot more planned for the application, and a roadmap etc. will soon show up on GitHub.
 
+## Error Handling
+
+Fog commands report problems using the structured `FogError` type. Errors are
+classified with codes and categories so they can be formatted consistently. See
+[docs/error-handling.md](docs/error-handling.md) for an overview of the error
+system, how to add new codes and how to enable verbose output with the
+`--verbose` flag.
+
 ## Contributions
 
 If you wish to contribute in any way (reporting bugs, requesting features, writing code), feel free to do so either by opening Issues or Pull Requests. For Pull Requests, just follow the standard pattern.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,73 @@
+# Fog Error Handling
+
+Fog uses a structured error system so commands and services can return rich error
+information. The key type is `FogError` which wraps an error code with
+contextual data.
+
+## FogError overview
+
+`FogError` is defined in `cmd/errors/types.go` and exposes methods for
+retrieving the error code, message and metadata such as the originating
+operation and component. A simplified example:
+
+```go
+err := errors.NewError(errors.ErrStackNotFound, "Stack 'my-stack' not found").
+    WithOperation("deploy").
+    WithComponent("cloudformation")
+```
+
+Every error includes:
+
+- a machine readable `ErrorCode`
+- severity and retryable information
+- context fields for debugging
+- optional user facing suggestions
+
+## Error codes
+
+Error codes are grouped by concern in `cmd/errors/types.go`. Functions in
+`cmd/errors/codes.go` map codes to categories and severity levels.
+Metadata can be retrieved with `GetErrorMetadata`:
+
+```go
+meta := errors.GetErrorMetadata(errors.ErrTemplateNotFound)
+```
+
+Refer to the source for the full list of codes.
+
+### Adding a new error code
+
+1. Declare a new constant in the appropriate section of `types.go`.
+2. Update `GetErrorCategory`, `GetErrorSeverity` and `IsRetryable` in
+   `codes.go` so the new code is classified correctly.
+3. Provide descriptive text and suggestions by extending `GetErrorMetadata`.
+4. Add unit tests in `cmd/errors` verifying the classification and metadata.
+
+## Error handling middleware
+
+All commands use `ErrorHandlingMiddleware` (`cmd/middleware/error_handler.go`).
+It converts unknown errors to `FogError`, formats them and prints the result via
+the configured UI handler. The middleware respects the error severity when
+choosing whether to show the message as info, warning or error.
+
+## Validation helpers
+
+`cmd/validation/errors.go` provides `ValidationErrorBuilder` for collecting
+multiple validation issues:
+
+```go
+builder := validation.NewValidationErrorBuilder("deploy")
+builder.RequiredField("stack-name").InvalidValue("region", "bad", "unknown")
+if builder.HasErrors() {
+    return builder.Build()
+}
+```
+
+When multiple errors are present `Build()` returns a `MultiError` so the
+middleware can display them together.
+
+## Verbose output
+
+Pass `--verbose` (or `-v`) to any command to include additional error context
+and stack traces in the console output. This flag is defined on the root command
+and applies to all sub-commands.


### PR DESCRIPTION
## Summary
- document FogError system and middleware usage
- explain how to add error codes and enable verbose output

## Testing
- `go test ./cmd/errors ./cmd/validation -v`
- `golangci-lint run ./cmd/errors ./cmd/validation` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68444d7e259c8333a96aff645e339d0c