### PR TITLE
[feature] add flag validation middleware

### DIFF
--- a/cmd/flags/middleware/preprocessing.go
+++ b/cmd/flags/middleware/preprocessing.go
@@ -1,0 +1,21 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/ArjenSchwarz/fog/cmd/registry"
+)
+
+// PreprocessingMiddleware is a placeholder for flag preprocessing logic.
+type PreprocessingMiddleware struct{}
+
+// NewPreprocessingMiddleware creates a new PreprocessingMiddleware.
+func NewPreprocessingMiddleware() *PreprocessingMiddleware { return &PreprocessingMiddleware{} }
+
+// Execute runs preprocessing before the next handler.
+func (m *PreprocessingMiddleware) Execute(ctx context.Context, next func(context.Context) error) error {
+	// Preprocessing logic would be added here.
+	return next(ctx)
+}
+
+var _ registry.Middleware = (*PreprocessingMiddleware)(nil)

--- a/cmd/flags/middleware/validation.go
+++ b/cmd/flags/middleware/validation.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/ArjenSchwarz/fog/cmd/flags"
+	"github.com/ArjenSchwarz/fog/cmd/registry"
+)
+
+// FlagValidationMiddleware runs flag validation before invoking the next handler.
+type FlagValidationMiddleware struct {
+	validator flags.FlagValidator
+}
+
+// NewFlagValidationMiddleware returns a new FlagValidationMiddleware.
+func NewFlagValidationMiddleware(validator flags.FlagValidator) *FlagValidationMiddleware {
+	return &FlagValidationMiddleware{validator: validator}
+}
+
+// Execute validates flags and then calls the next handler.
+func (m *FlagValidationMiddleware) Execute(ctx context.Context, next func(context.Context) error) error {
+	if err := m.validator.Validate(ctx, &flags.ValidationContext{}); err != nil {
+		return err
+	}
+	return next(ctx)
+}
+
+var _ registry.Middleware = (*FlagValidationMiddleware)(nil)

--- a/cmd/flags/middleware/validation_test.go
+++ b/cmd/flags/middleware/validation_test.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ArjenSchwarz/fog/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+type mockValidator struct {
+	err    error
+	called bool
+}
+
+func (m *mockValidator) Validate(ctx context.Context, vCtx *flags.ValidationContext) error {
+	m.called = true
+	return m.err
+}
+func (m *mockValidator) RegisterFlags(cmd *cobra.Command)           {}
+func (m *mockValidator) GetValidationRules() []flags.ValidationRule { return nil }
+
+func TestFlagValidationMiddlewareExecuteSuccess(t *testing.T) {
+	mv := &mockValidator{}
+	mw := NewFlagValidationMiddleware(mv)
+
+	nextCalled := false
+	next := func(ctx context.Context) error { nextCalled = true; return nil }
+
+	if err := mw.Execute(context.Background(), next); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !mv.called {
+		t.Errorf("validator not called")
+	}
+	if !nextCalled {
+		t.Errorf("next not called")
+	}
+}
+
+func TestFlagValidationMiddlewareExecuteError(t *testing.T) {
+	mv := &mockValidator{err: errors.New("fail")}
+	mw := NewFlagValidationMiddleware(mv)
+
+	called := false
+	next := func(ctx context.Context) error { called = true; return nil }
+
+	err := mw.Execute(context.Background(), next)
+	if err == nil || err.Error() != "fail" {
+		t.Fatalf("expected validation error, got %v", err)
+	}
+	if !mv.called {
+		t.Errorf("validator not called")
+	}
+	if called {
+		t.Errorf("next should not run on validation failure")
+	}
+}


### PR DESCRIPTION
## Summary
- add flag validation middleware for advanced flag validation
- stub out preprocessing middleware
- test middleware behavior

## Testing
- `go test ./cmd/flags/middleware -v`
- `gofmt -w cmd/flags/middleware/validation.go cmd/flags/middleware/preprocessing.go cmd/flags/middleware/validation_test.go`
- `golangci-lint run` *(fails: context deadline)*
- `go test ./... -v` *(fails: context deadline)*

------
https://chatgpt.com/codex/tasks/task_e_6844575e944c833399772d707c17807c