### PR TITLE
[bug] Fix T-695: Guard getExpectedAndActualTags against malformed tag payloads

### DIFF
--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -576,23 +576,44 @@ func getExpectedAndActualTags(expectedResources map[string]any, actualResources 
 	// if Tags exists in expectedResources, compare the list of tags with those in actualResources
 	tags := make(map[string]map[string]string)
 	// go through expectedResources["Tags"] and add each item in expectedTags
-	if expectedResources["Tags"] != nil {
-		for _, tag := range expectedResources["Tags"].([]any) {
-			tagMap := tag.(map[string]any)
-			tags[tagMap["Key"].(string)] = map[string]string{"Expected": tagMap["Value"].(string)}
+	if expectedTags, ok := expectedResources["Tags"].([]any); ok {
+		for _, tag := range expectedTags {
+			key, value, valid := extractTagKeyValue(tag)
+			if !valid {
+				continue
+			}
+			tags[key] = map[string]string{"Expected": value}
 		}
 	}
 	// go through actualResources["Tags"] and add each item in actualTags
-	if actualResources["Tags"] != nil {
-		for _, tag := range actualResources["Tags"].([]any) {
-			tagMap := tag.(map[string]any)
-			if tags[tagMap["Key"].(string)] == nil {
-				tags[tagMap["Key"].(string)] = map[string]string{"Expected": "", "Actual": tagMap["Value"].(string)}
+	if actualTags, ok := actualResources["Tags"].([]any); ok {
+		for _, tag := range actualTags {
+			key, value, valid := extractTagKeyValue(tag)
+			if !valid {
+				continue
 			}
-			tags[tagMap["Key"].(string)]["Actual"] = tagMap["Value"].(string)
+			if tags[key] == nil {
+				tags[key] = map[string]string{"Expected": "", "Actual": value}
+			}
+			tags[key]["Actual"] = value
 		}
 	}
 	return tags
+}
+
+// extractTagKeyValue safely extracts Key and Value strings from a tag entry.
+// Returns ("", "", false) if the entry is malformed.
+func extractTagKeyValue(tag any) (string, string, bool) {
+	tagMap, ok := tag.(map[string]any)
+	if !ok {
+		return "", "", false
+	}
+	key, keyOk := tagMap["Key"].(string)
+	value, valueOk := tagMap["Value"].(string)
+	if !keyOk || !valueOk {
+		return "", "", false
+	}
+	return key, value, true
 }
 
 func shouldTagBeHandled(tag string, drift types.StackResourceDrift) bool {

--- a/cmd/drift_test.go
+++ b/cmd/drift_test.go
@@ -950,3 +950,147 @@ func TestTagDifferences_MalformedPaths(t *testing.T) {
 		}
 	})
 }
+
+// TestGetExpectedAndActualTags_MalformedPayloads verifies that
+// getExpectedAndActualTags does not panic on malformed tag structures.
+// Regression tests for T-695.
+func TestGetExpectedAndActualTags_MalformedPayloads(t *testing.T) {
+	tests := map[string]struct {
+		expected map[string]any
+		actual   map[string]any
+		wantLen  int
+	}{
+		"nil Tags in both": {
+			expected: map[string]any{},
+			actual:   map[string]any{},
+			wantLen:  0,
+		},
+		"well-formed tags": {
+			expected: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": "Env", "Value": "prod"},
+				},
+			},
+			actual: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": "Env", "Value": "staging"},
+				},
+			},
+			wantLen: 1,
+		},
+		"Tags is a map instead of a slice": {
+			expected: map[string]any{
+				"Tags": map[string]any{"Key": "k"},
+			},
+			actual:  map[string]any{},
+			wantLen: 0,
+		},
+		"Tags entry is a string instead of a map": {
+			expected: map[string]any{
+				"Tags": []any{"not-a-map"},
+			},
+			actual:  map[string]any{},
+			wantLen: 0,
+		},
+		"Tag Key is an int instead of a string": {
+			expected: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": 123, "Value": "v"},
+				},
+			},
+			actual:  map[string]any{},
+			wantLen: 0,
+		},
+		"Tag Value is an int instead of a string": {
+			expected: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": "k", "Value": 456},
+				},
+			},
+			actual:  map[string]any{},
+			wantLen: 0,
+		},
+		"Tag missing Key field": {
+			expected: map[string]any{
+				"Tags": []any{
+					map[string]any{"Value": "v"},
+				},
+			},
+			actual:  map[string]any{},
+			wantLen: 0,
+		},
+		"Tag missing Value field": {
+			expected: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": "k"},
+				},
+			},
+			actual:  map[string]any{},
+			wantLen: 0,
+		},
+		"actual Tags is a map instead of a slice": {
+			expected: map[string]any{},
+			actual: map[string]any{
+				"Tags": map[string]any{"Key": "k"},
+			},
+			wantLen: 0,
+		},
+		"actual Tags entry is a non-map": {
+			expected: map[string]any{},
+			actual: map[string]any{
+				"Tags": []any{42},
+			},
+			wantLen: 0,
+		},
+		"actual Tag Key is non-string": {
+			expected: map[string]any{},
+			actual: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": true, "Value": "v"},
+				},
+			},
+			wantLen: 0,
+		},
+		"actual Tag Value is non-string": {
+			expected: map[string]any{},
+			actual: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": "k", "Value": []any{}},
+				},
+			},
+			wantLen: 0,
+		},
+		"mixed valid and malformed expected tags": {
+			expected: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": "Good", "Value": "yes"},
+					"bad-entry",
+					map[string]any{"Key": 123, "Value": "no"},
+				},
+			},
+			actual:  map[string]any{},
+			wantLen: 1,
+		},
+		"mixed valid and malformed actual tags": {
+			expected: map[string]any{},
+			actual: map[string]any{
+				"Tags": []any{
+					map[string]any{"Key": "Good", "Value": "yes"},
+					42,
+					map[string]any{"Missing": "fields"},
+				},
+			},
+			wantLen: 1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// The primary goal is to not panic; correct length is secondary.
+			result := getExpectedAndActualTags(tc.expected, tc.actual)
+			if len(result) != tc.wantLen {
+				t.Errorf("got %d tags, want %d; result=%v", len(result), tc.wantLen, result)
+			}
+		})
+	}
+}

--- a/specs/bugfixes/malformed-tag-payloads/report.md
+++ b/specs/bugfixes/malformed-tag-payloads/report.md
@@ -1,0 +1,76 @@
+# Bugfix Report: malformed-tag-payloads
+
+**Date:** 2025-07-14
+**Status:** Fixed
+**Transit:** T-695
+
+## Description of the Issue
+
+`getExpectedAndActualTags` in `cmd/drift.go` used unchecked type assertions on parsed drift properties. If AWS returned a malformed or non-standard tag structure (e.g. Tags as a map instead of a slice, non-map entries in the Tags slice, or non-string Key/Value fields), the function would panic, crashing the entire `fog stack drift` command.
+
+**Reproduction steps:**
+1. Call `getExpectedAndActualTags` with `map[string]any{"Tags": map[string]any{"Key":"k"}}` (Tags is a map, not a slice)
+2. Observe panic from type assertion: `interface {} is map[string]interface {}, not []interface {}`
+
+**Impact:** Drift command crashes on unexpected API payloads; users lose all drift results for the affected stack.
+
+## Investigation Summary
+
+- **Symptoms examined:** Panic on type assertion when Tags payload is non-standard
+- **Code inspected:** `cmd/drift.go` lines 575-596, `getExpectedAndActualTags` function
+- **Hypotheses tested:** All six type assertions in the function are unchecked and each can panic independently
+
+## Discovered Root Cause
+
+All type assertions in `getExpectedAndActualTags` use the single-value form (`x.(T)`) which panics on type mismatch, instead of the two-value comma-ok form (`v, ok := x.(T)`) which returns a zero value and `false`.
+
+**Defect type:** Missing validation / unchecked type assertions
+
+**Why it occurred:** The function was written assuming AWS always returns well-formed tag structures. This is true under normal operation but not guaranteed.
+
+**Contributing factors:** Go's type assertion syntax makes it easy to forget the safe two-value form when the developer expects a known structure.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/drift.go:575-606` — Replaced unchecked type assertions with comma-ok patterns; extracted a helper `extractTagKeyValue` that safely returns (key, value, ok). Malformed entries are silently skipped.
+- `cmd/drift_test.go` — Added `TestGetExpectedAndActualTags_MalformedPayloads` with 14 sub-tests covering all malformed variants.
+
+**Approach rationale:** Using comma-ok assertions is the idiomatic Go approach for safely handling interface values. Extracting a helper keeps the main function readable and avoids repeating the same validation logic for expected and actual tags.
+
+**Alternatives considered:**
+- `recover()` wrapper — would mask the problem and make debugging harder; not chosen.
+- Pre-validation with `reflect` — over-engineered for this use case; not chosen.
+
+## Regression Test
+
+**Test file:** `cmd/drift_test.go`
+**Test name:** `TestGetExpectedAndActualTags_MalformedPayloads`
+
+**What it verifies:** The function does not panic on any of 14 malformed tag payload variants, including non-slice Tags, non-map entries, non-string Key/Value, and missing fields. Also verifies that valid tags mixed with malformed ones are still correctly parsed.
+
+**Run command:** `go test ./cmd -run TestGetExpectedAndActualTags_MalformedPayloads -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/drift.go` | Replaced unchecked type assertions with safe comma-ok forms; added `extractTagKeyValue` helper |
+| `cmd/drift_test.go` | Added 14 regression tests for malformed tag payloads |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass (golangci-lint: 0 issues)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Always use the comma-ok form for type assertions on `any`/`interface{}` values from external data (API responses, parsed JSON)
+- Consider a linter rule (e.g. `forcetypeassert`) to flag single-value type assertions
+
+## Related
+
+- Transit ticket: T-695


### PR DESCRIPTION
## Summary

`getExpectedAndActualTags` in `cmd/drift.go` used unchecked type assertions that panic when AWS returns malformed tag structures (non-slice Tags, non-map entries, non-string Key/Value fields).

## Root Cause

All six type assertions used the single-value form (`x.(T)`) which panics on mismatch instead of the safe comma-ok form.

## Fix

- Replaced unchecked assertions with comma-ok patterns
- Extracted `extractTagKeyValue` helper for safe key/value extraction
- Malformed entries are silently skipped; valid entries are still processed

## Testing

- 14 regression tests covering all malformed payload variants
- Full test suite passes
- golangci-lint: 0 issues

See `specs/bugfixes/malformed-tag-payloads/report.md` for the full bugfix report.

Fixes T-695