### PR TITLE
[bug] Fix T-675: deployChangeset keeps running after ExecuteChangeSet failure

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -117,7 +117,15 @@ func deployTemplate(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if confirmAndDeployChangeset(changeset, &deployment, awsConfig) {
+	deployed, err := confirmAndDeployChangeset(changeset, &deployment, awsConfig)
+	if err != nil {
+		printMessage(formatError(err.Error()))
+		if deployment.IsNew {
+			deleteStackIfNewFunc(deployment, awsConfig)
+		}
+		os.Exit(1)
+	}
+	if deployed {
 		printDeploymentResults(&deployment, awsConfig, &deploymentLog)
 	}
 }
@@ -443,7 +451,7 @@ func deleteStackIfNew(deployment lib.DeployInfo, awsConfig config.AWSConfig) {
 	}
 }
 
-func deployChangeset(deployment lib.DeployInfo, awsConfig config.AWSConfig) {
+func deployChangeset(deployment lib.DeployInfo, awsConfig config.AWSConfig) error {
 	ctx := context.Background()
 	if !deployFlags.Quiet {
 		if deployFlags.NonInteractive {
@@ -454,8 +462,7 @@ func deployChangeset(deployment lib.DeployInfo, awsConfig config.AWSConfig) {
 	}
 	err := deployment.Changeset.DeployChangeset(ctx, awsConfig.CloudformationClient())
 	if err != nil {
-		printMessage(formatError("Could not execute changeset! See details below"))
-		fmt.Fprintln(os.Stderr, err)
+		return fmt.Errorf("could not execute changeset: %w", err)
 	}
 	latest := deployment.Changeset.CreationTime
 	time.Sleep(3 * time.Second)
@@ -470,6 +477,7 @@ func deployChangeset(deployment lib.DeployInfo, awsConfig config.AWSConfig) {
 	}
 	// One last time after the deployment finished in case of a timing mismatch
 	showEvents(deployment, latest, awsConfig, deployFlags.Quiet)
+	return nil
 }
 
 func showEvents(deployment lib.DeployInfo, latest time.Time, awsConfig config.AWSConfig, quiet bool) time.Time {

--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -158,8 +158,8 @@ func createAndShowChangeset(info *lib.DeployInfo, cfg config.AWSConfig, logObj *
 
 // confirmAndDeployChangeset asks for deployment confirmation and executes
 // the deployment if approved. It returns true when the stack was actually
-// deployed.
-func confirmAndDeployChangeset(changeset *lib.ChangesetInfo, info *lib.DeployInfo, cfg config.AWSConfig) bool {
+// deployed and an error if the deployment execution failed.
+func confirmAndDeployChangeset(changeset *lib.ChangesetInfo, info *lib.DeployInfo, cfg config.AWSConfig) (bool, error) {
 	var confirm bool
 	if deployFlags.NonInteractive {
 		confirm = true
@@ -167,11 +167,13 @@ func confirmAndDeployChangeset(changeset *lib.ChangesetInfo, info *lib.DeployInf
 		confirm = askForConfirmationFunc(string(texts.DeployChangesetMessageDeployConfirm))
 	}
 	if confirm {
-		deployChangesetFunc(*info, cfg)
-		return true
+		if err := deployChangesetFunc(*info, cfg); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 	deleteChangesetFunc(*info, cfg)
-	return false
+	return false, nil
 }
 
 // printDeploymentResults fetches the final stack state and prints the

--- a/cmd/deploy_helpers_test.go
+++ b/cmd/deploy_helpers_test.go
@@ -503,9 +503,11 @@ func TestConfirmAndDeployChangeset(t *testing.T) {
 	tests := map[string]struct {
 		nonInteractive bool
 		userConfirm    bool
+		deployErr      error
 		expectDeploy   bool
 		expectDelete   bool
 		expectReturn   bool
+		expectErr      bool
 	}{
 		"non-interactive auto-deploy": {
 			nonInteractive: true,
@@ -527,6 +529,14 @@ func TestConfirmAndDeployChangeset(t *testing.T) {
 			expectDeploy:   false,
 			expectDelete:   true,
 			expectReturn:   false,
+		},
+		"deploy fails with error": {
+			nonInteractive: true,
+			deployErr:      errors.New("ExecuteChangeSet failed: access denied"),
+			expectDeploy:   true,
+			expectDelete:   false,
+			expectReturn:   false,
+			expectErr:      true,
 		},
 	}
 
@@ -552,8 +562,9 @@ func TestConfirmAndDeployChangeset(t *testing.T) {
 			askForConfirmationFunc = func(string) bool {
 				return tc.userConfirm
 			}
-			deployChangesetFunc = func(info lib.DeployInfo, cfg config.AWSConfig) {
+			deployChangesetFunc = func(info lib.DeployInfo, cfg config.AWSConfig) error {
 				deployCalled = true
+				return tc.deployErr
 			}
 			deleteChangesetFunc = func(info lib.DeployInfo, cfg config.AWSConfig) {
 				deleteCalled = true
@@ -563,7 +574,11 @@ func TestConfirmAndDeployChangeset(t *testing.T) {
 				NonInteractive: tc.nonInteractive,
 			}
 
-			result := confirmAndDeployChangeset(&lib.ChangesetInfo{}, &lib.DeployInfo{}, config.AWSConfig{})
+			result, err := confirmAndDeployChangeset(&lib.ChangesetInfo{}, &lib.DeployInfo{}, config.AWSConfig{})
+
+			if (err != nil) != tc.expectErr {
+				t.Errorf("expected error=%v, got %v", tc.expectErr, err)
+			}
 
 			if result != tc.expectReturn {
 				t.Errorf("expected return value=%v, got %v", tc.expectReturn, result)

--- a/cmd/deploy_integration_test.go
+++ b/cmd/deploy_integration_test.go
@@ -271,7 +271,10 @@ func TestDeploymentWorkflow_EndToEnd(t *testing.T) {
 				}
 
 				// Confirm and deploy
-				deployed := confirmAndDeployChangeset(cs, &info, awsCfg)
+				deployed, err := confirmAndDeployChangeset(cs, &info, awsCfg)
+				if err != nil {
+					t.Fatalf("unexpected error during deploy: %v", err)
+				}
 
 				if tc.expectStackCreated && !deployed {
 					t.Error("expected stack to be deployed but it wasn't")

--- a/specs/bugfixes/deploy-changeset-execute-failure/report.md
+++ b/specs/bugfixes/deploy-changeset-execute-failure/report.md
@@ -1,0 +1,84 @@
+# Bugfix Report: deploy-changeset-execute-failure
+
+**Date:** 2026-04-14
+**Status:** Fixed
+**Ticket:** T-675
+
+## Description of the Issue
+
+When `ExecuteChangeSet` fails (e.g., due to permissions errors or API failures), the `deployChangeset` function prints an error message but continues executing into the event polling loop and final status handling. This produces misleading output and can result in a false-success command exit.
+
+**Reproduction steps:**
+1. Configure a deployment where `ExecuteChangeSet` will fail (e.g., insufficient permissions)
+2. Run `fog deploy` with the configuration
+3. Observe that fog prints "Could not execute changeset!" but continues polling for events
+
+**Impact:** Medium — users see misleading output after a deployment failure, and the command may exit with status 0 despite the changeset execution failing.
+
+## Investigation Summary
+
+- **Symptoms examined:** `deployChangeset` prints error but continues into event polling loop
+- **Code inspected:** `cmd/deploy.go` (deployChangeset), `cmd/deploy_helpers.go` (confirmAndDeployChangeset), caller in deploy command
+- **Hypotheses tested:** Confirmed that the error from `DeployChangeset()` is logged but not propagated; control flow continues unconditionally
+
+## Discovered Root Cause
+
+In `deployChangeset()`, the error returned by `deployment.Changeset.DeployChangeset()` is only printed to stderr — it is never returned or used to short-circuit execution. The function has no return value, so callers cannot detect the failure.
+
+**Defect type:** Missing error propagation
+
+**Why it occurred:** The original implementation treated the execute-changeset call as fire-and-forget, relying on downstream stack-status polling to detect failure. However, when the API call itself fails (before any stack operation begins), polling never observes a failure state.
+
+**Contributing factors:** The function signature `func deployChangeset(...) ` (no error return) made it impossible for callers to handle the failure.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/deploy.go:446` — Changed `deployChangeset` to return `error`; return immediately on `ExecuteChangeSet` failure instead of continuing into the event loop
+- `cmd/deploy_helpers.go:162` — Changed `confirmAndDeployChangeset` to return `(bool, error)` and propagate deployment errors
+- `cmd/deploy.go:120` — Updated caller to handle error: prints error, cleans up new stacks, and exits non-zero
+
+**Approach rationale:** Propagating the error through the call chain follows Go conventions and gives the caller full control over error handling. The command now exits non-zero on execute failure, ensuring CI/CD pipelines detect the problem.
+
+**Alternatives considered:**
+- Calling `os.Exit(1)` directly inside `deployChangeset` — rejected because it bypasses cleanup and makes testing difficult
+- Logging and continuing with a flag — rejected because downstream polling cannot detect pre-execution API failures
+
+## Regression Test
+
+**Test file:** `cmd/deploy_helpers_test.go`
+**Test name:** `TestConfirmAndDeployChangeset/deploy_fails_with_error`
+
+**What it verifies:** When `deployChangesetFunc` returns an error, `confirmAndDeployChangeset` returns `false` and propagates the error. The changeset is not deleted (since it was never executed).
+
+**Run command:** `go test ./cmd/ -run TestConfirmAndDeployChangeset -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/deploy.go` | `deployChangeset` returns `error`, early return on failure; caller handles error with non-zero exit |
+| `cmd/deploy_helpers.go` | `confirmAndDeployChangeset` returns `(bool, error)`, propagates deploy error |
+| `cmd/deploy_helpers_test.go` | Updated existing tests for new signatures, added error propagation test case |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Build succeeds (`go build -o fog`)
+- `golangci-lint run` reports 0 issues
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Functions that call AWS APIs should always return errors rather than printing and continuing
+- Use `error` return values consistently for operations that can fail
+- Consider adding a linter rule or code review checklist item for "error printed but not returned"
+
+## Related
+
+- Transit ticket T-675


### PR DESCRIPTION
## Summary

Fixes T-675: `deployChangeset` continues into event polling and final status handling after `ExecuteChangeSet` fails, producing misleading output and potentially a false-success exit.

## Root Cause

The error from `deployment.Changeset.DeployChangeset()` was printed to stderr but never returned — execution continued unconditionally into the event loop.

## Fix

- `deployChangeset` now returns `error` and stops immediately on `ExecuteChangeSet` failure
- `confirmAndDeployChangeset` propagates the error via `(bool, error)` return
- The deploy command handles the error: prints it, cleans up new stacks, and exits non-zero

## Testing

- Added regression test case `deploy_fails_with_error` to `TestConfirmAndDeployChangeset`
- All existing tests updated for new function signatures
- Full test suite passes, linter clean

See `specs/bugfixes/deploy-changeset-execute-failure/report.md` for the full bugfix report.