### PR TITLE
[bug] Fix T-676: Existing-stack deploy info drops configured account alias

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -144,7 +144,7 @@ func showDeploymentInfo(deployment lib.DeployInfo, awsConfig config.AWSConfig, q
 	if deployment.IsNew {
 		fmt.Fprintf(os.Stderr, "%v new stack '%v' to region %v of account %v\n\n", method, bold(deployFlags.StackName), awsConfig.Region, account)
 	} else {
-		fmt.Fprintf(os.Stderr, "%v stack '%v' in region %v of account %v\n\n", method, bold(deployFlags.StackName), awsConfig.Region, awsConfig.AccountID)
+		fmt.Fprintf(os.Stderr, "%v stack '%v' in region %v of account %v\n\n", method, bold(deployFlags.StackName), awsConfig.Region, account)
 	}
 	printBasicStackInfo(deployment, true, awsConfig)
 }

--- a/cmd/deploy_account_alias_test.go
+++ b/cmd/deploy_account_alias_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ArjenSchwarz/fog/config"
+	"github.com/ArjenSchwarz/fog/lib"
+)
+
+// TestShowDeploymentInfo_ExistingStackUsesAccountAlias verifies that the
+// first line of existing-stack deploy info includes the configured account
+// alias, not just the bare account ID. This is a regression test for T-676.
+func TestShowDeploymentInfo_ExistingStackUsesAccountAlias(t *testing.T) {
+	// Don't run in parallel due to global deployFlags state
+	oldFlags := deployFlags
+	defer func() { deployFlags = oldFlags }()
+
+	deployFlags = DeployFlags{
+		StackName: "existing-stack",
+		Dryrun:    false,
+	}
+
+	deployment := lib.DeployInfo{
+		StackName: "existing-stack",
+		IsNew:     false,
+	}
+	awsCfg := config.AWSConfig{
+		Region:       "eu-west-1",
+		AccountID:    "987654321098",
+		AccountAlias: "staging",
+	}
+
+	stderr := captureStderr(func() {
+		showDeploymentInfo(deployment, awsCfg, false)
+	})
+
+	// Check only the first line — the deployment summary line must use the
+	// formatted account display with alias, consistent with new-stack output.
+	firstLine := strings.SplitN(stderr, "\n", 2)[0]
+	if !strings.Contains(firstLine, "staging (987654321098)") {
+		t.Errorf("existing-stack deploy info first line should include account alias.\ngot:  %q\nwant substring: staging (987654321098)", firstLine)
+	}
+}
+
+// TestShowDeploymentInfo_ExistingStackNoAlias verifies that when no alias is
+// configured, the existing-stack first line still shows just the account ID.
+func TestShowDeploymentInfo_ExistingStackNoAlias(t *testing.T) {
+	oldFlags := deployFlags
+	defer func() { deployFlags = oldFlags }()
+
+	deployFlags = DeployFlags{
+		StackName: "existing-stack",
+		Dryrun:    false,
+	}
+
+	deployment := lib.DeployInfo{
+		StackName: "existing-stack",
+		IsNew:     false,
+	}
+	awsCfg := config.AWSConfig{
+		Region:    "us-east-1",
+		AccountID: "111111111111",
+	}
+
+	stderr := captureStderr(func() {
+		showDeploymentInfo(deployment, awsCfg, false)
+	})
+
+	firstLine := strings.SplitN(stderr, "\n", 2)[0]
+	if !strings.Contains(firstLine, "account 111111111111") {
+		t.Errorf("existing-stack deploy info without alias should show account ID.\ngot: %q", firstLine)
+	}
+}

--- a/cmd/output_golden_test.go
+++ b/cmd/output_golden_test.go
@@ -72,7 +72,7 @@ func TestShowDeploymentInfo_GoldenFiles(t *testing.T) {
 					method, tc.deployment.StackName, tc.awsConfig.Region, account))
 			} else {
 				buf.WriteString(fmt.Sprintf("%v stack '%v' in region %v of account %v\n",
-					method, tc.deployment.StackName, tc.awsConfig.Region, tc.awsConfig.AccountID))
+					method, tc.deployment.StackName, tc.awsConfig.Region, account))
 			}
 
 			// Assert against golden file (strip ANSI codes to test data correctness, not formatting)

--- a/cmd/testdata/golden/cmd/update_stack_deployment.golden
+++ b/cmd/testdata/golden/cmd/update_stack_deployment.golden
@@ -1,1 +1,1 @@
-Updating stack 'existing-stack' in region eu-west-1 of account 987654321098
+Updating stack 'existing-stack' in region eu-west-1 of account staging (987654321098)

--- a/specs/bugfixes/deploy-info-drops-account-alias/report.md
+++ b/specs/bugfixes/deploy-info-drops-account-alias/report.md
@@ -1,0 +1,81 @@
+# Bugfix Report: deploy-info-drops-account-alias
+
+**Date:** 2025-04-14
+**Status:** Fixed
+
+## Description of the Issue
+
+When deploying to an existing CloudFormation stack, the deployment info message printed the bare AWS account ID instead of the formatted account display that includes the configured alias. New-stack deployments correctly showed `alias (accountID)`, creating an inconsistency.
+
+**Reproduction steps:**
+1. Configure an account alias in fog.yaml (e.g., `accountalias: staging`)
+2. Deploy to an existing stack
+3. Observe: the info line shows only the account ID, not `staging (987654321098)`
+
+**Impact:** Low severity — cosmetic inconsistency in CLI output, but confusing when managing multiple AWS accounts.
+
+## Investigation Summary
+
+The `showDeploymentInfo` function in `cmd/deploy.go` computes the formatted account display string via `formatAccountDisplay(awsConfig.AccountID, awsConfig.AccountAlias)` and stores it in the `account` variable. However, only the new-stack branch uses `account`; the existing-stack branch directly uses `awsConfig.AccountID`.
+
+- **Symptoms examined:** Different output for new vs existing stack deployments
+- **Code inspected:** `cmd/deploy.go:showDeploymentInfo`, `cmd/deploy_helpers.go:formatAccountDisplay`
+- **Hypotheses tested:** Single hypothesis — the `else` branch bypasses the `account` variable
+
+## Discovered Root Cause
+
+**Defect type:** Logic error — inconsistent variable usage
+
+**Why it occurred:** The `account` variable was computed but not used in the `else` branch. The new-stack and existing-stack branches were likely written at different times, and the `else` branch was never updated to use the formatted display.
+
+**Contributing factors:** The existing golden test (`output_golden_test.go`) mirrored the same bug, so it never caught the inconsistency.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/deploy.go:139` — Changed `awsConfig.AccountID` to `account` in the existing-stack branch
+- `cmd/output_golden_test.go:75` — Fixed the same bug in the golden test
+- `cmd/testdata/golden/cmd/update_stack_deployment.golden` — Updated golden file to expect alias output
+
+**Approach rationale:** The `account` variable was already computed on line 134 for both branches — it just wasn't being used in the `else` path. Using it makes both branches consistent.
+
+**Alternatives considered:**
+- Inlining `formatAccountDisplay` in both branches — rejected as unnecessarily verbose; the variable already exists.
+
+## Regression Test
+
+**Test file:** `cmd/deploy_account_alias_test.go`
+**Test names:** `TestShowDeploymentInfo_ExistingStackUsesAccountAlias`, `TestShowDeploymentInfo_ExistingStackNoAlias`
+
+**What it verifies:** The first line of deployment info for existing stacks includes the account alias when configured, and shows just the account ID when no alias is set.
+
+**Run command:** `go test ./cmd -run TestShowDeploymentInfo_ExistingStack -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/deploy.go` | Use `account` variable in existing-stack branch |
+| `cmd/output_golden_test.go` | Fix same bug in golden test |
+| `cmd/testdata/golden/cmd/update_stack_deployment.golden` | Update expected output |
+| `cmd/deploy_account_alias_test.go` | New regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the first line of existing-stack output now shows `staging (987654321098)` instead of `987654321098`
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When a local variable is computed for use in multiple branches, audit all branches to ensure consistent usage
+- Golden tests should validate expected behavior independently, not mirror the implementation
+
+## Related
+
+- Transit ticket: T-676


### PR DESCRIPTION
## Bug Summary

`showDeploymentInfo` in `cmd/deploy.go` computed an account display string with alias via `formatAccountDisplay`, but only used it for new-stack deployments. For existing stacks, it printed `awsConfig.AccountID` directly, dropping the alias.

## Root Cause

Line 139 of `cmd/deploy.go` used `awsConfig.AccountID` instead of the already-computed `account` variable. The golden test mirrored the same bug, so it never caught the issue.

## Fix

- Use the `account` variable in both branches of `showDeploymentInfo`
- Fix the same bug in `output_golden_test.go`
- Update the golden file `update_stack_deployment.golden`
- Add regression tests in `deploy_account_alias_test.go`

## Verification

- [x] Regression tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)

See `specs/bugfixes/deploy-info-drops-account-alias/report.md` for full details.