### PR TITLE
[bug] Fix T-711: runPrechecks honors stop flag on execution errors

### DIFF
--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -115,7 +115,7 @@ func runPrechecks(info *lib.DeployInfo, logObj *lib.DeploymentLog) (string, bool
 		} else {
 			builder.WriteString(formatError(string(texts.FilePrecheckFailureContinue)))
 		}
-		return builder.String(), true
+		return builder.String(), viper.GetBool("templates.stop-on-failed-prechecks")
 	}
 	if info.PrechecksFailed {
 		logObj.PreChecks = lib.DeploymentLogPreChecksFailed

--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -110,12 +110,13 @@ func runPrechecks(info *lib.DeployInfo, logObj *lib.DeploymentLog) (string, bool
 		info.PrechecksFailed = true
 		logObj.PreChecks = lib.DeploymentLogPreChecksFailed
 		builder.WriteString(formatError(err.Error()))
-		if viper.GetBool("templates.stop-on-failed-prechecks") {
+		stopOnFailed := viper.GetBool("templates.stop-on-failed-prechecks")
+		if stopOnFailed {
 			builder.WriteString(formatError(string(texts.FilePrecheckFailureStop)))
 		} else {
 			builder.WriteString(formatError(string(texts.FilePrecheckFailureContinue)))
 		}
-		return builder.String(), viper.GetBool("templates.stop-on-failed-prechecks")
+		return builder.String(), stopOnFailed
 	}
 	if info.PrechecksFailed {
 		logObj.PreChecks = lib.DeploymentLogPreChecksFailed

--- a/cmd/deploy_helpers_test.go
+++ b/cmd/deploy_helpers_test.go
@@ -281,6 +281,74 @@ func TestRunPrechecks(t *testing.T) {
 	}
 }
 
+// TestRunPrechecks_T711_ExecutionErrorHonorsStopFlag is a regression test for
+// T-711: runPrechecks must return abort=false when an execution error occurs
+// (e.g. missing command) and stop-on-failed-prechecks is disabled.
+// Before the fix, the error path always returned abort=true regardless of the
+// stop flag, causing deployments to abort even when the user explicitly chose
+// to continue on precheck failures.
+func TestRunPrechecks_T711_ExecutionErrorHonorsStopFlag(t *testing.T) {
+	tests := map[string]struct {
+		precheckCommands     []string
+		stopOnFailedPrecheck bool
+		wantAbort            bool
+		wantOutputContains   string
+	}{
+		"missing command with stop flag disabled should not abort": {
+			precheckCommands:     []string{"nonexistent-cmd-t711 $TEMPLATEPATH"},
+			stopOnFailedPrecheck: false,
+			wantAbort:            false,
+			wantOutputContains:   "cannot be found",
+		},
+		"missing command with stop flag enabled should abort": {
+			precheckCommands:     []string{"nonexistent-cmd-t711 $TEMPLATEPATH"},
+			stopOnFailedPrecheck: true,
+			wantAbort:            true,
+			wantOutputContains:   "cannot be found",
+		},
+		"unsafe command with stop flag disabled should not abort": {
+			precheckCommands:     []string{"rm -rf /"},
+			stopOnFailedPrecheck: false,
+			wantAbort:            false,
+			wantOutputContains:   "unsafe command",
+		},
+		"unsafe command with stop flag enabled should abort": {
+			precheckCommands:     []string{"rm -rf /"},
+			stopOnFailedPrecheck: true,
+			wantAbort:            true,
+			wantOutputContains:   "unsafe command",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			viper.Set("templates.prechecks", tc.precheckCommands)
+			viper.Set("templates.stop-on-failed-prechecks", tc.stopOnFailedPrecheck)
+
+			info := lib.DeployInfo{TemplateRelativePath: "test"}
+			logObj := lib.DeploymentLog{}
+
+			out, abort := runPrechecks(&info, &logObj)
+
+			if abort != tc.wantAbort {
+				t.Errorf("expected abort=%v, got %v (stop flag=%v)", tc.wantAbort, abort, tc.stopOnFailedPrecheck)
+			}
+
+			if !info.PrechecksFailed {
+				t.Error("expected PrechecksFailed=true for execution error")
+			}
+
+			if logObj.PreChecks != lib.DeploymentLogPreChecksFailed {
+				t.Errorf("expected log status %q, got %q", lib.DeploymentLogPreChecksFailed, logObj.PreChecks)
+			}
+
+			if tc.wantOutputContains != "" && !strings.Contains(strings.ToLower(out), strings.ToLower(tc.wantOutputContains)) {
+				t.Errorf("expected output to contain %q, got %q", tc.wantOutputContains, out)
+			}
+		})
+	}
+}
+
 // TestPrepareDeployment tests the prepareDeployment helper function
 func TestPrepareDeployment(t *testing.T) {
 	// Don't run in parallel due to global state (viper, deployFlags, outputsettings)

--- a/cmd/deploy_helpers_test.go
+++ b/cmd/deploy_helpers_test.go
@@ -222,7 +222,7 @@ func TestRunPrechecks(t *testing.T) {
 			precheckCommands:     []string{"nonexistent-cmd-t577 $TEMPLATEPATH"},
 			stopOnFailedPrecheck: false,
 			wantPrechecksPassed:  false,
-			wantAbort:            true,
+			wantAbort:            false,
 			wantLogStatus:        lib.DeploymentLogPreChecksFailed,
 			wantOutputContains:   "cannot be found",
 		},

--- a/specs/bugfixes/prechecks-stop-flag-regression/report.md
+++ b/specs/bugfixes/prechecks-stop-flag-regression/report.md
@@ -1,0 +1,78 @@
+# Bugfix Report: prechecks-stop-flag-regression
+
+**Date:** 2026-04-14
+**Status:** Fixed
+**Transit Ticket:** T-711
+
+## Description of the Issue
+
+`runPrechecks` in `cmd/deploy_helpers.go` always aborts the deployment when `lib.RunPrechecks` returns an execution or configuration error (e.g. missing command, unsafe command), regardless of the `templates.stop-on-failed-prechecks` setting.
+
+**Reproduction steps:**
+1. Configure a precheck command that fails to execute (e.g., a non-existent binary).
+2. Set `templates.stop-on-failed-prechecks=false`.
+3. Run `fog deploy`.
+4. Deployment exits early instead of continuing after recording the precheck failure.
+
+**Impact:** Any deployment with a misconfigured precheck command is blocked even when the user has explicitly opted to continue on precheck failures. This is a regression from T-577.
+
+## Investigation Summary
+
+- **Symptoms examined:** `runPrechecks` returns `abort=true` for execution errors even when stop flag is disabled.
+- **Code inspected:** `cmd/deploy_helpers.go` — the `runPrechecks` function, specifically the `if err != nil` branch.
+- **Hypotheses tested:** Compared the error branch with the non-error failure branch (`if info.PrechecksFailed`), which correctly returns `stopOnFailed`.
+
+## Discovered Root Cause
+
+**Defect type:** Logic error — hardcoded return value
+
+In `cmd/deploy_helpers.go`, the `if err != nil` branch of `runPrechecks` returns `(builder.String(), true)` unconditionally. The comment says "the stop flag is honored" but the code doesn't actually check the flag.
+
+**Why it occurred:** When T-577 added execution-error handling, the error path was written to always abort (defensive coding) but should have mirrored the non-error failure path which checks `viper.GetBool("templates.stop-on-failed-prechecks")`.
+
+**Contributing factors:** The existing test case `"execution error missing command marks failed"` encoded the buggy behavior by asserting `wantAbort: true` with `stopOnFailedPrecheck: false`, masking the regression.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/deploy_helpers.go:~109` — Changed `return builder.String(), true` to `return builder.String(), viper.GetBool("templates.stop-on-failed-prechecks")`
+- `cmd/deploy_helpers_test.go` — Fixed existing test case to expect `wantAbort: false` when stop flag is disabled; added dedicated regression test `TestRunPrechecks_T711_ExecutionErrorHonorsStopFlag`
+
+**Approach rationale:** The fix mirrors the pattern already used in the non-error failure path, ensuring consistent behavior regardless of whether the precheck failed during execution or produced a non-zero exit code.
+
+**Alternatives considered:**
+- Returning a separate error type to let `deployTemplate` decide — over-engineering for a boolean flag check.
+
+## Regression Test
+
+**Test file:** `cmd/deploy_helpers_test.go`
+**Test name:** `TestRunPrechecks_T711_ExecutionErrorHonorsStopFlag`
+
+**What it verifies:** That execution errors (missing command, unsafe command) in prechecks respect the stop-on-failed-prechecks flag — returning `abort=false` when the flag is disabled and `abort=true` when enabled.
+
+**Run command:** `go test ./cmd/ -run TestRunPrechecks_T711 -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/deploy_helpers.go` | Fix hardcoded `true` return to respect stop flag |
+| `cmd/deploy_helpers_test.go` | Fix existing test + add regression test for T-711 |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding error-handling branches, ensure they follow the same control-flow patterns as existing branches for the same function.
+- Test cases for error paths should include both stop-flag states (enabled and disabled).
+
+## Related
+
+- T-577: Original precheck execution error handling
+- `specs/bugfixes/precheck-execution-errors/report.md`: Related previous bugfix


### PR DESCRIPTION
## Summary

Fixes T-711: `runPrechecks` always aborted on execution errors regardless of `stop-on-failed-prechecks` setting.

## Root Cause

In `cmd/deploy_helpers.go`, the `if err != nil` branch returned `abort=true` unconditionally. The comment said "the stop flag is honored" but the code didn't check it.

## Fix

Changed hardcoded `return builder.String(), true` to `return builder.String(), viper.GetBool("templates.stop-on-failed-prechecks")`, matching the non-error failure path behavior.

Also fixed existing test that encoded the buggy behavior and added dedicated regression test `TestRunPrechecks_T711_ExecutionErrorHonorsStopFlag`.

## Verification

- Regression test passes (`go test ./cmd/ -run TestRunPrechecks_T711 -v`)
- Full test suite passes (`go test ./...`)
- Linter passes (`golangci-lint run`)

See: `specs/bugfixes/prechecks-stop-flag-regression/report.md`