### PR TITLE
[bug] Fix T-717: Guard GetParametersMap against nil CloudFormation parameter fields

### DIFF
--- a/lib/stacks.go
+++ b/lib/stacks.go
@@ -861,11 +861,20 @@ func (deployment *DeployInfo) GetExecutionTimes(ctx context.Context, svc CloudFo
 	return result, nil
 }
 
-// GetParametersMap converts a slice of parameters into a map of key-value pairs
+// GetParametersMap converts a slice of parameters into a map of key-value pairs.
+// Entries with a nil ParameterKey are skipped. A nil ParameterValue is stored as
+// an empty string so callers never encounter a nil dereference.
 func GetParametersMap(params []types.Parameter) *map[string]any {
 	result := make(map[string]any)
 	for _, param := range params {
-		result[*param.ParameterKey] = *param.ParameterValue
+		if param.ParameterKey == nil {
+			continue
+		}
+		value := ""
+		if param.ParameterValue != nil {
+			value = *param.ParameterValue
+		}
+		result[*param.ParameterKey] = value
 	}
 	return &result
 }

--- a/lib/stacks_test.go
+++ b/lib/stacks_test.go
@@ -729,6 +729,32 @@ func TestGetParametersMap(t *testing.T) {
 				"Key3": "Value3",
 			},
 		},
+		// Regression: nil ParameterKey should be skipped (T-717)
+		"nil key is skipped": {
+			params: []types.Parameter{
+				{ParameterKey: nil, ParameterValue: strPtr("OrphanValue")},
+				{ParameterKey: strPtr("Key1"), ParameterValue: strPtr("Value1")},
+			},
+			want: map[string]any{
+				"Key1": "Value1",
+			},
+		},
+		// Regression: nil ParameterValue should map to empty string (T-717)
+		"nil value maps to empty string": {
+			params: []types.Parameter{
+				{ParameterKey: strPtr("RedactedKey"), ParameterValue: nil},
+			},
+			want: map[string]any{
+				"RedactedKey": "",
+			},
+		},
+		// Regression: both key and value nil should be skipped (T-717)
+		"nil key and nil value is skipped": {
+			params: []types.Parameter{
+				{ParameterKey: nil, ParameterValue: nil},
+			},
+			want: map[string]any{},
+		},
 	}
 
 	for name, tc := range tests {

--- a/specs/bugfixes/nil-parameters-map/report.md
+++ b/specs/bugfixes/nil-parameters-map/report.md
@@ -1,0 +1,72 @@
+# Bugfix Report: nil-parameters-map
+
+**Date:** 2026-04-14
+**Status:** Fixed
+
+## Description of the Issue
+
+`lib.GetParametersMap` panics with a nil pointer dereference when AWS CloudFormation returns a `types.Parameter` whose `ParameterKey` or `ParameterValue` field is nil. Both fields are `*string` pointers and AWS may leave them nil for redacted or unresolved values.
+
+**Reproduction steps:**
+1. Call `GetParametersMap` with a `[]types.Parameter` containing an entry where `ParameterKey` is nil.
+2. Observe a `SIGSEGV` panic at `lib/stacks.go:868`.
+
+**Impact:** Any drift or report path that passes stack parameters through `GetParametersMap` can crash the entire process when AWS returns nil fields.
+
+## Investigation Summary
+
+- **Symptoms examined:** Nil pointer dereference panic in `GetParametersMap`.
+- **Code inspected:** `lib/stacks.go` (lines 864-871), `cmd/drift.go:192` (sole caller).
+- **Hypotheses tested:** Only one hypothesis needed — the pointer dereferences are unguarded.
+
+## Discovered Root Cause
+
+**Defect type:** Missing nil-pointer validation.
+
+**Why it occurred:** The function assumed both `ParameterKey` and `ParameterValue` would always be non-nil, but the AWS SDK v2 `types.Parameter` struct uses `*string` pointers which can legitimately be nil.
+
+**Contributing factors:** AWS documentation does not guarantee these fields are always populated. Responses with redacted SSM parameters or partially resolved values can contain nil fields.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/stacks.go:865-878` — Added nil guard: skip entries with nil key; map nil value to empty string.
+
+**Approach rationale:** Skipping nil keys is the only safe option (no meaningful map key exists). Mapping nil values to empty string preserves the key in the result, which is the least surprising behaviour for callers that iterate over the map.
+
+**Alternatives considered:**
+- Return an error — rejected because every caller would need error handling for a rare edge case that has a safe default.
+- Use a sentinel value like `"<nil>"` — rejected because empty string is more conventional and less likely to leak into user-facing output.
+
+## Regression Test
+
+**Test file:** `lib/stacks_test.go`
+**Test names:** `TestGetParametersMap/nil_key_is_skipped`, `TestGetParametersMap/nil_value_maps_to_empty_string`, `TestGetParametersMap/nil_key_and_nil_value_is_skipped`
+
+**What it verifies:** That nil `ParameterKey` entries are silently skipped, nil `ParameterValue` entries are stored as `""`, and fully-nil entries are skipped.
+
+**Run command:** `go test ./lib/ -run TestGetParametersMap -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/stacks.go` | Added nil guards to `GetParametersMap` |
+| `lib/stacks_test.go` | Added three regression test cases for nil key/value handling |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When working with AWS SDK v2 types, always treat `*string` fields as potentially nil.
+- Consider a project-wide linter rule or convention for dereferencing pointer fields from external SDK types.
+
+## Related
+
+- Transit ticket: T-717


### PR DESCRIPTION
## Summary

`GetParametersMap` in `lib/stacks.go` dereferenced `*param.ParameterKey` and `*param.ParameterValue` without nil checks. AWS `types.Parameter` fields are `*string` pointers and may be nil for redacted/unresolved values, causing a panic on drift/report paths.

## Root Cause

Missing nil-pointer validation on pointer-typed fields from the AWS SDK v2.

## Fix

- Skip entries with nil `ParameterKey`
- Map nil `ParameterValue` to empty string
- Added 3 regression tests covering nil key, nil value, and both-nil scenarios

See `specs/bugfixes/nil-parameters-map/report.md` for the full bugfix report.

Fixes T-717