### PR TITLE
Fix T-731: Guard CompareNaclEntries Against Nil Nested EC2 Pointers

### DIFF
--- a/lib/ec2.go
+++ b/lib/ec2.go
@@ -71,10 +71,10 @@ func CompareNaclEntries(nacl1 types.NetworkAclEntry, nacl2 types.NetworkAclEntry
 		return false
 	}
 	if nacl1.IcmpTypeCode != nil && nacl2.IcmpTypeCode != nil {
-		if *nacl1.IcmpTypeCode.Code != *nacl2.IcmpTypeCode.Code {
+		if !int32PointerValueMatch(nacl1.IcmpTypeCode.Code, nacl2.IcmpTypeCode.Code) {
 			return false
 		}
-		if *nacl1.IcmpTypeCode.Type != *nacl2.IcmpTypeCode.Type {
+		if !int32PointerValueMatch(nacl1.IcmpTypeCode.Type, nacl2.IcmpTypeCode.Type) {
 			return false
 		}
 	}
@@ -86,10 +86,10 @@ func CompareNaclEntries(nacl1 types.NetworkAclEntry, nacl2 types.NetworkAclEntry
 		return false
 	}
 	if nacl1.PortRange != nil && nacl2.PortRange != nil {
-		if *nacl1.PortRange.From != *nacl2.PortRange.From {
+		if !int32PointerValueMatch(nacl1.PortRange.From, nacl2.PortRange.From) {
 			return false
 		}
-		if *nacl1.PortRange.To != *nacl2.PortRange.To {
+		if !int32PointerValueMatch(nacl1.PortRange.To, nacl2.PortRange.To) {
 			return false
 		}
 	}
@@ -216,6 +216,20 @@ func GetRouteTarget(route types.Route) string {
 		target = *route.VpcPeeringConnectionId
 	}
 	return target
+}
+
+// int32PointerValueMatch checks if two int32 pointers have equal values;
+// if both are nil, they match;
+// if only 1 is nil, they don't match;
+// otherwise the values need to match
+func int32PointerValueMatch(pointer1 *int32, pointer2 *int32) bool {
+	if pointer1 == nil && pointer2 == nil {
+		return true
+	}
+	if pointer1 == nil || pointer2 == nil {
+		return false
+	}
+	return *pointer1 == *pointer2
 }
 
 // stringPointerValueMatch checks if two string pointers have equal values;

--- a/lib/ec2_test.go
+++ b/lib/ec2_test.go
@@ -196,6 +196,21 @@ func TestCompareNaclEntries(t *testing.T) {
 	portdifffrom.PortRange = &types.PortRange{From: aws.Int32(42), To: aws.Int32(444)}
 	portdiffto := fullnacl
 	portdiffto.PortRange = &types.PortRange{From: aws.Int32(443), To: aws.Int32(42)}
+	// Regression tests for nil nested pointers (T-731)
+	icmpNilCode := fullnacl
+	icmpNilCode.IcmpTypeCode = &types.IcmpTypeCode{Code: nil, Type: aws.Int32(-1)}
+	icmpNilType := fullnacl
+	icmpNilType.IcmpTypeCode = &types.IcmpTypeCode{Code: aws.Int32(12), Type: nil}
+	icmpBothNilFields := fullnacl
+	icmpBothNilFields.IcmpTypeCode = &types.IcmpTypeCode{Code: nil, Type: nil}
+	icmpBothNilFieldsCopy := icmpBothNilFields
+	portNilFrom := fullnacl
+	portNilFrom.PortRange = &types.PortRange{From: nil, To: aws.Int32(444)}
+	portNilTo := fullnacl
+	portNilTo.PortRange = &types.PortRange{From: aws.Int32(443), To: nil}
+	portBothNilFields := fullnacl
+	portBothNilFields.PortRange = &types.PortRange{From: nil, To: nil}
+	portBothNilFieldsCopy := portBothNilFields
 	tests := []struct {
 		name string
 		args args
@@ -217,6 +232,15 @@ func TestCompareNaclEntries(t *testing.T) {
 		{"PortRange = nil mismatch fails", args{nacl1: fullnacl, nacl2: portnil}, false},
 		{"PortRange From different mismatch fails", args{nacl1: fullnacl, nacl2: portdifffrom}, false},
 		{"PortRange To different mismatch fails", args{nacl1: fullnacl, nacl2: portdiffto}, false},
+		// T-731: nil nested pointer guards
+		{"ICMP nil Code vs non-nil Code mismatch fails", args{nacl1: fullnacl, nacl2: icmpNilCode}, false},
+		{"ICMP nil Type vs non-nil Type mismatch fails", args{nacl1: fullnacl, nacl2: icmpNilType}, false},
+		{"ICMP both nil inner fields match each other", args{nacl1: icmpBothNilFields, nacl2: icmpBothNilFieldsCopy}, true},
+		{"ICMP both nil inner fields vs full mismatch fails", args{nacl1: fullnacl, nacl2: icmpBothNilFields}, false},
+		{"PortRange nil From vs non-nil From mismatch fails", args{nacl1: fullnacl, nacl2: portNilFrom}, false},
+		{"PortRange nil To vs non-nil To mismatch fails", args{nacl1: fullnacl, nacl2: portNilTo}, false},
+		{"PortRange both nil inner fields match each other", args{nacl1: portBothNilFields, nacl2: portBothNilFieldsCopy}, true},
+		{"PortRange both nil inner fields vs full mismatch fails", args{nacl1: fullnacl, nacl2: portBothNilFields}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -498,6 +522,34 @@ func Test_stringPointerValueMatch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := stringPointerValueMatch(tt.args.pointer1, tt.args.pointer2); got != tt.want {
 				t.Errorf("stringPointerValueMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_int32PointerValueMatch(t *testing.T) {
+	type args struct {
+		pointer1 *int32
+		pointer2 *int32
+	}
+	value1 := int32(42)
+	othervalue1 := int32(42)
+	value2 := int32(99)
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"Match when both are nil", args{}, true},
+		{"Match when values are the same", args{pointer1: &value1, pointer2: &othervalue1}, true},
+		{"No match when pointer 1 is nil", args{pointer2: &value1}, false},
+		{"No match when pointer 2 is nil", args{pointer1: &value1}, false},
+		{"No match when values are different", args{pointer1: &value1, pointer2: &value2}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := int32PointerValueMatch(tt.args.pointer1, tt.args.pointer2); got != tt.want {
+				t.Errorf("int32PointerValueMatch() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/specs/bugfixes/guard-nacl-entries-nil-pointers/report.md
+++ b/specs/bugfixes/guard-nacl-entries-nil-pointers/report.md
@@ -1,0 +1,82 @@
+# Bugfix Report: Guard CompareNaclEntries Against Nil Nested EC2 Pointers
+
+**Date:** 2026-04-14
+**Status:** Fixed
+**Ticket:** T-731
+
+## Description of the Issue
+
+`CompareNaclEntries` in `lib/ec2.go` dereferenced nested pointer fields (`IcmpTypeCode.Code`, `IcmpTypeCode.Type`, `PortRange.From`, `PortRange.To`) without nil checks. While the parent structs (`IcmpTypeCode`, `PortRange`) were guarded, their inner `*int32` fields were not.
+
+**Reproduction steps:**
+1. Call `CompareNaclEntries` with two entries where both have a non-nil `IcmpTypeCode` but one has a nil `Code` or `Type` field
+2. Observe runtime panic due to nil pointer dereference
+
+**Impact:** A malformed or partial AWS response (or mocked fixture) with nil inner fields would crash drift detection with a runtime panic instead of returning a safe comparison result.
+
+## Investigation Summary
+
+- **Symptoms examined:** Potential nil pointer dereference in nested EC2 struct fields
+- **Code inspected:** `lib/ec2.go` lines 73-80 (IcmpTypeCode) and lines 88-95 (PortRange)
+- **Hypotheses tested:** The existing `stringPointerValueMatch` helper safely handles nil `*string` pointers; the same pattern was missing for `*int32` fields
+
+## Discovered Root Cause
+
+The function guarded `IcmpTypeCode` and `PortRange` containers for nil but assumed their inner pointer fields (`Code`, `Type`, `From`, `To`) were always non-nil when the container was present.
+
+**Defect type:** Missing nil validation on nested pointer fields
+
+**Why it occurred:** The AWS SDK EC2 types use `*int32` for these fields, meaning they can independently be nil even when the parent struct is present. The original code only checked the parent.
+
+**Contributing factors:** AWS SDK v2 uses pointer types extensively; partial API responses or test fixtures may omit inner fields.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/ec2.go` - Added `int32PointerValueMatch` helper (mirrors `stringPointerValueMatch`) for safe `*int32` comparison
+- `lib/ec2.go` - Replaced raw `*` dereferences in `IcmpTypeCode.Code/Type` and `PortRange.From/To` comparisons with `int32PointerValueMatch` calls
+
+**Approach rationale:** Follows the existing `stringPointerValueMatch` pattern already used throughout the file, keeping the code consistent and easy to understand.
+
+**Alternatives considered:**
+- Inline nil checks before each dereference — rejected because it duplicates logic and is less readable than the helper pattern already established
+
+## Regression Test
+
+**Test file:** `lib/ec2_test.go`
+**Test names:** `TestCompareNaclEntries/*nil*` and `Test_int32PointerValueMatch`
+
+**What it verifies:**
+- Nil `IcmpTypeCode.Code` vs non-nil returns false (no panic)
+- Nil `IcmpTypeCode.Type` vs non-nil returns false (no panic)
+- Both nil inner ICMP fields match each other
+- Nil `PortRange.From` vs non-nil returns false (no panic)
+- Nil `PortRange.To` vs non-nil returns false (no panic)
+- Both nil inner PortRange fields match each other
+- `int32PointerValueMatch` handles all nil/non-nil combinations
+
+**Run command:** `go test ./lib/ -run 'TestCompareNaclEntries|Test_int32PointerValueMatch' -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/ec2.go` | Added `int32PointerValueMatch` helper; used it in `CompareNaclEntries` for safe nested pointer comparison |
+| `lib/ec2_test.go` | Added 8 regression test cases for nil nested pointers and 5 unit tests for `int32PointerValueMatch` |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`go test ./...`)
+- [x] Code formatted (`go fmt`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When comparing AWS SDK struct fields that use pointer types, always use nil-safe helper functions rather than direct dereference
+- Consider using generics for pointer comparison helpers to avoid creating type-specific variants (future improvement)
+
+## Related
+
+- Transit ticket: T-731


### PR DESCRIPTION
## Bug

`CompareNaclEntries` dereferenced nested `*int32` pointer fields (`IcmpTypeCode.Code`, `IcmpTypeCode.Type`, `PortRange.From`, `PortRange.To`) without nil checks, causing runtime panics when AWS returns partial responses or test fixtures omit inner fields.

## Root Cause

The parent structs (`IcmpTypeCode`, `PortRange`) were nil-guarded, but their inner pointer members were assumed non-nil.

## Fix

- Added `int32PointerValueMatch` helper mirroring the existing `stringPointerValueMatch` pattern
- Replaced raw dereferences with the nil-safe helper calls

## Tests

- 8 new regression test cases for nil nested pointer combinations in `TestCompareNaclEntries`
- 5 unit tests for `Test_int32PointerValueMatch`
- Full test suite passes

## Report

See `specs/bugfixes/guard-nacl-entries-nil-pointers/report.md`

Fixes T-731