### PR TITLE
[bug] Fix T-741: FilterRoutesByLogicalId misses RouteTableId values in Ref-map format

### DIFF
--- a/lib/template.go
+++ b/lib/template.go
@@ -321,17 +321,23 @@ func ParseTemplateString(template string, parameters *map[string]any) (CfnTempla
 	return parsedTemplate, nil
 }
 
-// resourceIdMatchesLogical checks whether a resource property value (which can be
-// a string like "REF: LogicalName" or a map like {"Fn::ImportValue": "ExportName"})
-// refers to the same physical resource as logicalId. For string values the logical
-// name is compared directly; for Fn::ImportValue maps the import name is resolved
-// through logicalToPhysical and compared against the physical ID of logicalId.
+// resourceIdMatchesLogical checks whether a resource property value refers to the
+// same physical resource as logicalId. It handles three property formats:
+//   - string "REF: LogicalName" — the logical name is compared directly
+//   - map {"Ref": "LogicalName"} — the logical name is compared directly
+//   - map {"Fn::ImportValue": "ExportName"} — the export is resolved through
+//     logicalToPhysical and compared against the physical ID of logicalId
 func resourceIdMatchesLogical(prop any, logicalId string, logicalToPhysical map[string]string) bool {
 	switch value := prop.(type) {
 	case string:
 		refId := strings.TrimPrefix(value, "REF: ")
 		return refId == logicalId
 	case map[string]any:
+		// Handle {"Ref": "LogicalId"} format (raw-map / non-stringified refs)
+		if refName, ok := value["Ref"].(string); ok {
+			return refName == logicalId
+		}
+		// Handle {"Fn::ImportValue": "ExportName"} format
 		if importName, ok := value["Fn::ImportValue"].(string); ok {
 			importPhysical, importOk := logicalToPhysical[importName]
 			logicalPhysical, logicalOk := logicalToPhysical[logicalId]

--- a/lib/template_test.go
+++ b/lib/template_test.go
@@ -1245,6 +1245,161 @@ func TestFilterRoutesByLogicalId_FnImportValue(t *testing.T) {
 	}
 }
 
+// TestFilterRoutesByLogicalId_RefMap verifies that routes using {"Ref": "LogicalId"}
+// map format for RouteTableId are correctly matched. This is a regression test for
+// T-741 where resourceIdMatchesLogical only handled "REF: " strings and
+// Fn::ImportValue maps, missing the Ref-map format entirely.
+func TestFilterRoutesByLogicalId_RefMap(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: aws.String("GW"), ParameterValue: aws.String("igw-ref123")},
+	}
+	logicalToPhysical := map[string]string{
+		"MyRouteTable": "rtb-abc123",
+	}
+
+	template := CfnTemplateBody{
+		Resources: map[string]CfnTemplateResource{
+			"RefRoute": {
+				Type: "AWS::EC2::Route",
+				Properties: map[string]any{
+					"RouteTableId":         map[string]any{"Ref": "MyRouteTable"},
+					"DestinationCidrBlock": "0.0.0.0/0",
+					"GatewayId":            map[string]any{"Ref": "GW"},
+				},
+			},
+			"StringRoute": {
+				Type: "AWS::EC2::Route",
+				Properties: map[string]any{
+					"RouteTableId":         "REF: MyRouteTable",
+					"DestinationCidrBlock": "10.0.0.0/8",
+					"GatewayId":            "local",
+				},
+			},
+			"OtherRefRoute": {
+				Type: "AWS::EC2::Route",
+				Properties: map[string]any{
+					"RouteTableId":         map[string]any{"Ref": "OtherRouteTable"},
+					"DestinationCidrBlock": "192.168.0.0/16",
+					"GatewayId":            "local",
+				},
+			},
+		},
+		Conditions: map[string]bool{},
+	}
+
+	results := FilterRoutesByLogicalId("MyRouteTable", template, params, logicalToPhysical)
+
+	// Both the Ref-map route and the string-based route should match
+	if len(results) != 2 {
+		t.Errorf("Expected 2 routes, got %d", len(results))
+	}
+
+	// Ref-map route should be found
+	if route, ok := results["0.0.0.0/0"]; ok {
+		if *route.GatewayId != "igw-ref123" {
+			t.Errorf("Expected gateway igw-ref123, got %s", *route.GatewayId)
+		}
+	} else {
+		t.Errorf("Expected Ref-map default route not found")
+	}
+
+	// String-based route should also be found
+	if _, ok := results["10.0.0.0/8"]; !ok {
+		t.Errorf("Expected string-based route not found")
+	}
+
+	// OtherRouteTable route should NOT be included
+	if _, ok := results["192.168.0.0/16"]; ok {
+		t.Errorf("Expected OtherRouteTable route not to be included")
+	}
+}
+
+// TestResourceIdMatchesLogical_RefMap verifies that resourceIdMatchesLogical
+// handles the {"Ref": "LogicalId"} map format. Regression test for T-741.
+func TestResourceIdMatchesLogical_RefMap(t *testing.T) {
+	logicalToPhysical := map[string]string{
+		"MyResource": "phys-123",
+	}
+
+	tests := []struct {
+		name      string
+		prop      any
+		logicalId string
+		want      bool
+	}{
+		{
+			name:      "Ref map matches logical ID",
+			prop:      map[string]any{"Ref": "MyResource"},
+			logicalId: "MyResource",
+			want:      true,
+		},
+		{
+			name:      "Ref map does not match different logical ID",
+			prop:      map[string]any{"Ref": "OtherResource"},
+			logicalId: "MyResource",
+			want:      false,
+		},
+		{
+			name:      "string REF still works",
+			prop:      "REF: MyResource",
+			logicalId: "MyResource",
+			want:      true,
+		},
+		{
+			name:      "Fn::ImportValue still works",
+			prop:      map[string]any{"Fn::ImportValue": "MyResource"},
+			logicalId: "MyResource",
+			want:      true,
+		},
+		{
+			name:      "nil prop returns false",
+			prop:      nil,
+			logicalId: "MyResource",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resourceIdMatchesLogical(tt.prop, tt.logicalId, logicalToPhysical)
+			if got != tt.want {
+				t.Errorf("resourceIdMatchesLogical(%v, %q) = %v, want %v", tt.prop, tt.logicalId, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFilterNaclEntriesByLogicalId_RefMap verifies that NACL entries using
+// {"Ref": "LogicalId"} map format for NetworkAclId are correctly matched.
+// This ensures the fix for T-741 also covers NACL filtering.
+func TestFilterNaclEntriesByLogicalId_RefMap(t *testing.T) {
+	params := []cfntypes.Parameter{}
+	logicalToPhysical := map[string]string{}
+
+	template := CfnTemplateBody{
+		Resources: map[string]CfnTemplateResource{
+			"NaclEntry1": {
+				Type: "AWS::EC2::NetworkAclEntry",
+				Properties: map[string]any{
+					"NetworkAclId": map[string]any{"Ref": "MyNacl"},
+					"RuleNumber":   float64(100),
+					"Protocol":     "-1",
+					"RuleAction":   "allow",
+					"Egress":       false,
+					"CidrBlock":    "10.0.0.0/8",
+				},
+			},
+		},
+		Conditions: map[string]bool{},
+	}
+
+	results := FilterNaclEntriesByLogicalId("MyNacl", template, params, logicalToPhysical)
+
+	if len(results) != 1 {
+		t.Errorf("Expected 1 NACL entry, got %d", len(results))
+	}
+}
+
 // TestFilterTGWRoutesByLogicalId_FnImportValue verifies that TGW routes using
 // Fn::ImportValue for TransitGatewayRouteTableId are correctly filtered instead of panicking.
 func TestFilterTGWRoutesByLogicalId_FnImportValue(t *testing.T) {

--- a/specs/bugfixes/ref-map-route-filter/report.md
+++ b/specs/bugfixes/ref-map-route-filter/report.md
@@ -1,0 +1,84 @@
+# Bugfix Report: ref-map-route-filter
+
+**Date:** 2026-04-14
+**Status:** Fixed
+**Transit:** T-741
+
+## Description of the Issue
+
+`FilterRoutesByLogicalId` (and `FilterNaclEntriesByLogicalId`) failed to match resources whose `RouteTableId` or `NetworkAclId` was expressed as a `{"Ref": "LogicalId"}` map. This meant that when CloudFormation templates contained raw-map Ref values instead of the stringified `"REF: LogicalId"` format, routes and NACL entries were silently skipped during drift comparisons.
+
+**Reproduction steps:**
+1. Provide a CloudFormation template where a Route resource has `"RouteTableId": {"Ref": "MyRouteTable"}`
+2. Call `FilterRoutesByLogicalId("MyRouteTable", ...)` with that template
+3. Observe that the route is not included in the results despite the matching logical ID
+
+**Impact:** Drift comparisons could report incomplete results, missing valid routes/NACLs attached to a route table when templates use the Ref-map format.
+
+## Investigation Summary
+
+- **Symptoms examined:** `FilterRoutesByLogicalId` returns fewer routes than expected when `RouteTableId` uses `{"Ref": "..."}` format
+- **Code inspected:** `lib/template.go:resourceIdMatchesLogical`, `lib/tgw_routetables.go:tgwRouteMatchesRouteTable`
+- **Hypotheses tested:** The `tgwRouteMatchesRouteTable` function already handles `{"Ref": "..."}` correctly (lines 182-187), confirming this was a known format that `resourceIdMatchesLogical` was missing
+
+## Discovered Root Cause
+
+`resourceIdMatchesLogical` only handled two property formats in its type switch:
+1. `string` — matching `"REF: LogicalId"` after prefix stripping
+2. `map[string]any` — matching only `{"Fn::ImportValue": "..."}` maps
+
+The `{"Ref": "LogicalId"}` map format was never checked in the `map[string]any` branch.
+
+**Defect type:** Missing case in type switch — incomplete format handling
+
+**Why it occurred:** The function was originally written for the stringified `"REF: "` format. When `Fn::ImportValue` support was added, only that specific map key was handled. The `{"Ref": "..."}` map format (used when templates bypass stringification) was overlooked.
+
+**Contributing factors:** The TGW equivalent (`tgwRouteMatchesRouteTable`) was written later and does handle all formats, but the fix was not back-ported to the shared `resourceIdMatchesLogical` helper.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/template.go:334-337` — Added `{"Ref": "LogicalId"}` handling in the `map[string]any` branch of `resourceIdMatchesLogical`, checked before the existing `Fn::ImportValue` case
+- `lib/template.go:324-328` — Updated function doc comment to document the three supported formats
+
+**Approach rationale:** The fix mirrors the existing pattern in `tgwRouteMatchesRouteTable` (lines 182-187) and is the minimal change needed. By fixing `resourceIdMatchesLogical` rather than the callers, both `FilterRoutesByLogicalId` and `FilterNaclEntriesByLogicalId` are fixed simultaneously.
+
+**Alternatives considered:**
+- Refactoring `tgwRouteMatchesRouteTable` to use `resourceIdMatchesLogical` — not chosen because `tgwRouteMatchesRouteTable` also handles a plain physical ID string comparison that doesn't apply to the general case
+
+## Regression Test
+
+**Test file:** `lib/template_test.go`
+**Test names:**
+- `TestFilterRoutesByLogicalId_RefMap` — end-to-end test with Ref-map routes
+- `TestResourceIdMatchesLogical_RefMap` — unit test covering all format variants
+- `TestFilterNaclEntriesByLogicalId_RefMap` — ensures NACL filtering also works with Ref-maps
+
+**What they verify:** Routes and NACL entries with `{"Ref": "LogicalId"}` format are correctly matched by their respective filter functions, while non-matching Ref-map entries are excluded.
+
+**Run command:** `go test ./lib/ -run "TestFilterRoutesByLogicalId_RefMap|TestResourceIdMatchesLogical_RefMap|TestFilterNaclEntriesByLogicalId_RefMap" -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/template.go` | Added `{"Ref": "..."}` handling in `resourceIdMatchesLogical` |
+| `lib/template_test.go` | Added 3 regression tests for Ref-map format |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`go test ./...`)
+- [x] Linters/validators pass (`golangci-lint run`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding a new property format to one matching function, audit other functions that perform similar matching (e.g., `resourceIdMatchesLogical` vs `tgwRouteMatchesRouteTable`) to ensure consistency
+- Consider consolidating format-matching logic into a single shared helper to avoid divergence
+
+## Related
+
+- T-741: FilterRoutesByLogicalId misses RouteTableId values in Ref-map format
+- `lib/tgw_routetables.go:tgwRouteMatchesRouteTable` — reference implementation that already handled all formats


### PR DESCRIPTION
## Summary

`resourceIdMatchesLogical` only handled `"REF: LogicalId"` strings and `{"Fn::ImportValue": ...}` maps. It did not handle `{"Ref": "LogicalId"}` map format, causing `FilterRoutesByLogicalId` and `FilterNaclEntriesByLogicalId` to skip valid resources when templates use raw-map Ref values.

## Root Cause

The `map[string]any` branch in `resourceIdMatchesLogical` checked for `Fn::ImportValue` but not for `Ref`. The equivalent TGW function (`tgwRouteMatchesRouteTable`) already handled this format correctly.

## Fix

Added `{"Ref": "LogicalId"}` handling in the `map[string]any` branch of `resourceIdMatchesLogical`, before the existing `Fn::ImportValue` check.

## Testing

- 3 new regression tests covering Ref-map format for routes, NACLs, and direct unit tests
- Full test suite passes
- Linter clean

See `specs/bugfixes/ref-map-route-filter/report.md` for the full bugfix report.

Fixes T-741