### PR TITLE
[bug] Fix T-749: report command leaks raw stack names to stdout

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -191,11 +191,8 @@ func generateReport() error {
 	}
 
 	// Generate report for each stack
-	for _, stackkey := range stackskeys {
-		fmt.Println(stackkey)
-		if err := generateStackReport(ctx, stacks[stackkey], doc, awsConfig); err != nil {
-			return err
-		}
+	if err := buildStackReports(ctx, stacks, stackskeys, doc, awsConfig); err != nil {
+		return err
 	}
 
 	// Get output options with S3/file configuration if needed
@@ -220,6 +217,17 @@ func generateReport() error {
 		}
 	}
 
+	return nil
+}
+
+// buildStackReports iterates over the sorted stack keys and adds each
+// stack's report sections to the document builder.
+func buildStackReports(ctx context.Context, stacks map[string]lib.CfnStack, stackKeys []string, doc *output.Builder, awsConfig config.AWSConfig) error {
+	for _, stackKey := range stackKeys {
+		if err := generateStackReport(ctx, stacks[stackKey], doc, awsConfig); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cmd/report_stdout_leak_test.go
+++ b/cmd/report_stdout_leak_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ArjenSchwarz/fog/config"
+	"github.com/ArjenSchwarz/fog/lib"
+	output "github.com/ArjenSchwarz/go-output/v2"
+	"github.com/spf13/viper"
+)
+
+// TestBuildStackReports_NoRawStackNamesToStdout verifies that building a
+// report for multiple stacks does not leak raw stack names to stdout. Before
+// the fix, the stack iteration loop contained a bare fmt.Println(stackkey)
+// which injected plain text into stdout for every stack. This polluted
+// machine-readable output (JSON, CSV) and mixed unexpected lines into CLI
+// and Lambda report output.
+func TestBuildStackReports_NoRawStackNamesToStdout(t *testing.T) {
+	// Not parallel: captureBothStreams redirects global os.Stdout,
+	// which would interfere with other parallel tests writing to stdout.
+	viper.Reset()
+	viper.SetDefault("timezone", "UTC")
+	t.Cleanup(func() { viper.Reset() })
+
+	oldSettings := settings
+	settings = &config.Config{}
+	t.Cleanup(func() { settings = oldSettings })
+
+	now := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	awsConfig := config.AWSConfig{
+		AccountID: "111111111111",
+		Region:    "us-east-1",
+	}
+
+	// Pre-populate events so GetEvents doesn't call AWS
+	stackAlpha := lib.CfnStack{
+		Name: "alpha-stack",
+		Id:   "arn:aws:cloudformation:us-east-1:111111111111:stack/alpha-stack/aaa",
+		Events: []lib.StackEvent{
+			{
+				Type:      "Create",
+				Success:   true,
+				StartDate: now,
+				EndDate:   now.Add(30 * time.Second),
+			},
+		},
+	}
+	stackBeta := lib.CfnStack{
+		Name: "beta-stack",
+		Id:   "arn:aws:cloudformation:us-east-1:111111111111:stack/beta-stack/bbb",
+		Events: []lib.StackEvent{
+			{
+				Type:      "Update",
+				Success:   true,
+				StartDate: now.Add(1 * time.Hour),
+				EndDate:   now.Add(1*time.Hour + 45*time.Second),
+			},
+		},
+	}
+
+	stacks := map[string]lib.CfnStack{
+		stackAlpha.Id: stackAlpha,
+		stackBeta.Id:  stackBeta,
+	}
+
+	stackKeys := []string{stackAlpha.Id, stackBeta.Id}
+
+	var buildErr, renderErr error
+
+	stdout, _ := captureBothStreams(func() {
+		ctx := context.Background()
+		doc := output.New()
+		doc.Header("Test Report")
+
+		// Call the extracted function that contains the stack iteration loop
+		if err := buildStackReports(ctx, stacks, stackKeys, doc, awsConfig); err != nil {
+			buildErr = err
+			return
+		}
+
+		builtDoc := doc.Build()
+		out := output.NewOutput(
+			output.WithFormat(output.JSON()),
+			output.WithWriter(output.NewStdoutWriter()),
+		)
+		if err := out.Render(context.Background(), builtDoc); err != nil {
+			renderErr = err
+		}
+	})
+
+	if buildErr != nil {
+		t.Fatalf("buildStackReports returned error: %v", buildErr)
+	}
+	if renderErr != nil {
+		t.Fatalf("failed to render output: %v", renderErr)
+	}
+
+	// Verify that raw stack ARNs/keys do not appear as standalone lines in stdout.
+	// They may legitimately appear inside rendered JSON values, but should never
+	// be on their own line outside of the rendered output.
+	for _, key := range stackKeys {
+		for _, line := range strings.Split(stdout, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if trimmed == key {
+				t.Errorf("raw stack key %q leaked to stdout as a standalone line", key)
+			}
+		}
+	}
+}

--- a/specs/bugfixes/report-stdout-leak/report.md
+++ b/specs/bugfixes/report-stdout-leak/report.md
@@ -1,0 +1,80 @@
+# Bugfix Report: report-stdout-leak
+
+**Date:** 2025-06-15
+**Status:** Fixed
+
+## Description of the Issue
+
+The `report` command leaks raw stack names (ARN keys) directly to stdout during report rendering. A bare `fmt.Println(stackkey)` call in the stack iteration loop of `generateReport()` injects plain text lines into stdout for every stack being reported.
+
+**Reproduction steps:**
+1. Run `fog stack report` with any stack or set of stacks
+2. Observe raw ARN strings printed to stdout before the rendered report output
+3. When using `--output json`, the JSON output is interspersed with plain text lines
+
+**Impact:** Medium — pollutes machine-readable output (JSON, CSV), causes unexpected lines in CLI/Lambda report output, and breaks downstream parsing of report output.
+
+## Investigation Summary
+
+- **Symptoms examined:** Extra plain-text lines appearing in stdout containing stack ARN keys
+- **Code inspected:** `cmd/report.go`, specifically the `generateReport()` function's stack iteration loop
+- **Hypotheses tested:** Confirmed the `fmt.Println(stackkey)` call is the sole source of the leak; no other direct stdout writes exist in the rendering path
+
+## Discovered Root Cause
+
+A debug `fmt.Println(stackkey)` call was left in the stack iteration loop inside `generateReport()` at `cmd/report.go:195`.
+
+**Defect type:** Debug statement left in production code
+
+**Why it occurred:** The `fmt.Println` was likely added during development for debugging purposes and was not removed before merging.
+
+**Contributing factors:** The `generateReport()` function was difficult to unit test because it calls AWS directly, so the stdout leak was not caught by existing tests.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/report.go` — Extracted the stack iteration loop into a new `buildStackReports()` helper function and removed the `fmt.Println(stackkey)` call from it
+- `cmd/report_stdout_leak_test.go` — Added regression test `TestBuildStackReports_NoRawStackNamesToStdout` that captures stdout and verifies no raw stack keys leak
+
+**Approach rationale:** Extracting the loop into a helper function makes it directly testable without needing AWS mocks, while the fix itself is simply removing the debug print statement.
+
+**Alternatives considered:**
+- Gating the print behind a debug/verbose flag — unnecessary complexity for what is clearly a leftover debug statement
+- Only removing the line without extracting — would leave the code path untestable
+
+## Regression Test
+
+**Test file:** `cmd/report_stdout_leak_test.go`
+**Test name:** `TestBuildStackReports_NoRawStackNamesToStdout`
+
+**What it verifies:** That iterating over multiple stacks and building report sections does not write raw stack keys to stdout. Uses stdout capture to detect any leaked lines.
+
+**Run command:** `go test ./cmd/ -run TestBuildStackReports_NoRawStackNamesToStdout -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/report.go` | Extracted loop into `buildStackReports()`, removed `fmt.Println(stackkey)` |
+| `cmd/report_stdout_leak_test.go` | New regression test file |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Verified the `fmt.Println(stackkey)` is the only direct stdout write in the rendering path
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Avoid using `fmt.Println` for debug output; use structured logging or stderr-based debug output instead
+- Extract complex functions into testable helpers so stdout behaviour can be verified in tests
+- Consider adding a CI check that flags bare `fmt.Print*` calls in non-test code
+
+## Related
+
+- Transit ticket: T-749


### PR DESCRIPTION
## Bug

The `report` command's `generateReport()` contained a bare `fmt.Println(stackkey)` inside the stack iteration loop, which leaked raw stack ARN keys to stdout for every stack. This polluted machine-readable output (JSON, CSV) and mixed unexpected lines into CLI and Lambda report output.

## Root Cause

A debug `fmt.Println(stackkey)` was left in production code at `cmd/report.go:195`.

## Fix

- Extracted the stack iteration loop into a `buildStackReports()` helper function for testability
- Removed the `fmt.Println(stackkey)` call
- Added regression test `TestBuildStackReports_NoRawStackNamesToStdout`
- Added bugfix report at `specs/bugfixes/report-stdout-leak/report.md`

## Verification

- Regression test captures stdout and verifies no raw stack keys leak as standalone lines
- Full test suite passes
- Linter passes (0 issues)

Fixes T-749