### PR TITLE
[bug] Fix T-761: GetFreshStack falls back to StackName when StackArn is empty

### DIFF
--- a/lib/stacks.go
+++ b/lib/stacks.go
@@ -502,9 +502,15 @@ func (deployment *DeployInfo) GetChangeset(ctx context.Context, svc CloudFormati
 	return results, nil
 }
 
-// GetFreshStack retrieves the latest stack information from AWS
+// GetFreshStack retrieves the latest stack information from AWS.
+// It prefers StackArn for lookups but falls back to StackName when
+// StackArn is empty (e.g. before a changeset has been created).
 func (deployment *DeployInfo) GetFreshStack(ctx context.Context, svc CloudFormationDescribeStacksAPI) (types.Stack, error) {
-	return GetStack(ctx, &deployment.StackArn, svc)
+	identifier := deployment.StackArn
+	if identifier == "" {
+		identifier = deployment.StackName
+	}
+	return GetStack(ctx, &identifier, svc)
 }
 
 // GetStack retrieves the stack information, using cached data if available

--- a/lib/stacks_refactored_test.go
+++ b/lib/stacks_refactored_test.go
@@ -538,6 +538,45 @@ func TestDeployInfo_IsNewStack(t *testing.T) {
 			},
 			want: false,
 		},
+		// T-761: When StackArn is empty, GetFreshStack must fall back to
+		// StackName so that REVIEW_IN_PROGRESS stacks are correctly
+		// classified as new. With multiple stacks in the account, an
+		// empty StackArn causes an unscoped DescribeStacks call that
+		// returns all stacks, triggering a "found multiple stacks" error.
+		"REVIEW_IN_PROGRESS with empty StackArn - new": {
+			stackName: "review-no-arn",
+			stackArn:  "", // StackArn is empty before changeset creation
+			setup: func(client *testutil.MockCFNClient) {
+				stack := testutil.NewStackBuilder("review-no-arn").
+					WithStatus(types.StackStatusReviewInProgress).
+					Build()
+				client.Stacks["review-no-arn"] = stack
+				// A second stack in the account makes an unscoped
+				// DescribeStacks call return >1 results and fail.
+				other := testutil.NewStackBuilder("other-stack").
+					WithStatus(types.StackStatusCreateComplete).
+					Build()
+				client.Stacks["other-stack"] = other
+			},
+			want: true,
+		},
+		// T-761: An existing stack with empty StackArn should not be
+		// misclassified as new even when other stacks exist.
+		"CREATE_COMPLETE with empty StackArn - not new": {
+			stackName: "existing-no-arn",
+			stackArn:  "", // StackArn is empty before changeset creation
+			setup: func(client *testutil.MockCFNClient) {
+				stack := testutil.NewStackBuilder("existing-no-arn").
+					WithStatus(types.StackStatusCreateComplete).
+					Build()
+				client.Stacks["existing-no-arn"] = stack
+				other := testutil.NewStackBuilder("another-stack").
+					WithStatus(types.StackStatusUpdateComplete).
+					Build()
+				client.Stacks["another-stack"] = other
+			},
+			want: false,
+		},
 	}
 
 	for name, tc := range tests {
@@ -562,6 +601,32 @@ func TestDeployInfo_IsNewStack(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestDeployInfo_GetFreshStack_FallsBackToStackName verifies that
+// GetFreshStack uses StackName when StackArn is empty (T-761).
+func TestDeployInfo_GetFreshStack_FallsBackToStackName(t *testing.T) {
+	t.Helper()
+
+	mockClient := testutil.NewMockCFNClient()
+	stack := testutil.NewStackBuilder("my-stack").
+		WithStatus(types.StackStatusReviewInProgress).
+		Build()
+	mockClient.Stacks["my-stack"] = stack
+	// Add a second stack to ensure an unscoped call would fail
+	other := testutil.NewStackBuilder("other-stack").
+		WithStatus(types.StackStatusCreateComplete).
+		Build()
+	mockClient.Stacks["other-stack"] = other
+
+	deployment := DeployInfo{
+		StackName: "my-stack",
+		StackArn:  "", // empty before changeset creation
+	}
+
+	got, err := deployment.GetFreshStack(context.Background(), mockClient)
+	require.NoError(t, err)
+	assert.Equal(t, types.StackStatusReviewInProgress, got.StackStatus)
 }
 
 // TestDeployInfo_CreateChangeSet tests the CreateChangeSet method

--- a/specs/bugfixes/isnewstack-empty-stackarn/report.md
+++ b/specs/bugfixes/isnewstack-empty-stackarn/report.md
@@ -1,0 +1,79 @@
+# Bugfix Report: IsNewStack Empty StackArn
+
+**Date:** 2025-07-14
+**Status:** Fixed
+**Transit:** T-761
+
+## Description of the Issue
+
+`IsNewStack` could misclassify `REVIEW_IN_PROGRESS` stacks as not-new when `StackArn` was empty. This happens because `GetFreshStack` unconditionally used `StackArn` to look up the stack. Before a changeset is created, `StackArn` is typically empty, causing an unscoped `DescribeStacks` API call that either errors (multiple stacks in the account) or returns the wrong stack.
+
+**Reproduction steps:**
+1. Set `deployment.StackName` to an existing stack in `REVIEW_IN_PROGRESS` status
+2. Leave `deployment.StackArn` empty (default path before changeset creation)
+3. Call `deployment.IsNewStack(...)` in an account with multiple stacks
+4. Observe `GetFreshStack` fails or returns incorrect stack, causing `IsNewStack` to return `false`
+
+**Impact:** `ChangesetType` could be set to `UPDATE` instead of `CREATE` for new stacks in review. Behaviour was non-deterministic depending on the number of stacks in the AWS account.
+
+## Investigation Summary
+
+- **Symptoms examined:** `IsNewStack` returning `false` for `REVIEW_IN_PROGRESS` stacks when `StackArn` is empty
+- **Code inspected:** `lib/stacks.go` — `IsNewStack`, `GetFreshStack`, `GetStack`, `StackExists`
+- **Hypotheses tested:** The `GetFreshStack` method was identified as the source — it passes `deployment.StackArn` to `GetStack` without checking for an empty value
+
+## Discovered Root Cause
+
+`GetFreshStack` always passed `deployment.StackArn` to the package-level `GetStack` function. When `StackArn` was empty, `GetStack` omitted the `StackName` filter from the `DescribeStacks` API call, causing it to return all stacks in the account. With multiple stacks, this triggered an error (`expected exactly one stack`); with a single stack, it could silently return the wrong one.
+
+**Defect type:** Missing fallback / empty-value guard
+
+**Why it occurred:** `StackArn` is only populated after changeset creation (`deployment.StackArn = changeset.StackID`), but `IsNewStack` is called before changeset creation during `prepareDeployment`.
+
+**Contributing factors:** `StackExists` (called first in `IsNewStack`) correctly uses `StackName`, masking the inconsistency — the problem only surfaced in the subsequent `GetFreshStack` call.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/stacks.go:506-511` — `GetFreshStack` now checks whether `StackArn` is empty and falls back to `StackName`
+
+**Approach rationale:** This is the minimal, localised fix. The fallback is safe because `StackName` is always set when a deployment is constructed, and using it as identifier is exactly what `StackExists` already does in the same flow.
+
+**Alternatives considered:**
+- Populating `StackArn` inside `StackExists` from `RawStack.StackId` — rejected because it mutates state as a side effect of an existence check, and would couple `StackExists` to `DeployInfo` field management
+
+## Regression Test
+
+**Test file:** `lib/stacks_refactored_test.go`
+**Test names:**
+- `TestDeployInfo_IsNewStack/REVIEW_IN_PROGRESS_with_empty_StackArn_-_new`
+- `TestDeployInfo_IsNewStack/CREATE_COMPLETE_with_empty_StackArn_-_not_new`
+- `TestDeployInfo_GetFreshStack_FallsBackToStackName`
+
+**What it verifies:** With multiple stacks in the mock account and an empty `StackArn`, `IsNewStack` correctly identifies `REVIEW_IN_PROGRESS` as new and `CREATE_COMPLETE` as not-new. `GetFreshStack` successfully resolves by `StackName` when `StackArn` is empty.
+
+**Run command:** `go test ./lib/... -run "TestDeployInfo_IsNewStack|TestDeployInfo_GetFreshStack_FallsBackToStackName" -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/stacks.go` | `GetFreshStack` falls back to `StackName` when `StackArn` is empty |
+| `lib/stacks_refactored_test.go` | Added 3 regression tests covering the empty-StackArn path |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`go test ./...`)
+- [x] Linters pass (`golangci-lint run`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Functions that accept an identifier should validate it is non-empty before use, or document the precondition
+- When a struct has both a name and an ARN field, prefer a helper that resolves the best available identifier rather than hard-coding one field
+
+## Related
+
+- Transit ticket: T-761


### PR DESCRIPTION
## Summary

`GetFreshStack` unconditionally used `deployment.StackArn` for lookups. Before changeset creation, `StackArn` is empty, causing an unscoped `DescribeStacks` call that either errors (multiple stacks) or silently returns the wrong stack. This made `IsNewStack` misclassify `REVIEW_IN_PROGRESS` stacks as not-new, setting `ChangesetType` to `UPDATE` instead of `CREATE`.

## Root Cause

`GetFreshStack` passed `deployment.StackArn` directly to `GetStack`. When empty, `GetStack` omits the `StackName` filter from the API call, returning all stacks in the account.

## Fix

`GetFreshStack` now falls back to `StackName` when `StackArn` is empty — matching what `StackExists` already does in the same `IsNewStack` flow.

## Testing

- Added 3 regression tests with multiple stacks in the mock client and empty `StackArn`
- Full test suite passes
- Linter passes

## Bugfix Report

See `specs/bugfixes/isnewstack-empty-stackarn/report.md`

Fixes T-761