### PR TITLE
[bug] Fix T-775: Guard template route parameter resolution against nil CloudFormation pointers

### DIFF
--- a/lib/template.go
+++ b/lib/template.go
@@ -468,6 +468,9 @@ func extractCidrBlock(properties map[string]any, key string, params []cfntypes.P
 // resolveParameterValue resolves a parameter reference to its actual value
 func resolveParameterValue(refname string, params []cfntypes.Parameter) string {
 	for _, parameter := range params {
+		if parameter.ParameterKey == nil {
+			continue
+		}
 		if *parameter.ParameterKey == refname {
 			if parameter.ResolvedValue != nil {
 				return *parameter.ResolvedValue
@@ -603,10 +606,13 @@ func stringPointer(array map[string]any, params []cfntypes.Parameter, logicalToP
 				result = logicalToPhysical[refname]
 			} else {
 				for _, parameter := range params {
+					if parameter.ParameterKey == nil {
+						continue
+					}
 					if *parameter.ParameterKey == refname {
 						if parameter.ResolvedValue != nil {
 							result = *parameter.ResolvedValue
-						} else {
+						} else if parameter.ParameterValue != nil {
 							result = *parameter.ParameterValue
 						}
 					}

--- a/lib/template_test.go
+++ b/lib/template_test.go
@@ -1497,3 +1497,104 @@ Resources:
 		})
 	}
 }
+
+// TestResolveParameterValue_NilPointerKey verifies that resolveParameterValue
+// does not panic when a parameter entry has a nil ParameterKey.
+func TestResolveParameterValue_NilPointerKey(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: nil, ParameterValue: aws.String("value1")},
+		{ParameterKey: aws.String("GoodKey"), ParameterValue: aws.String("good-value")},
+	}
+
+	// Should skip the nil-key parameter and still resolve a valid one
+	got := resolveParameterValue("GoodKey", params)
+	if got != "good-value" {
+		t.Errorf("resolveParameterValue() = %q, want %q", got, "good-value")
+	}
+
+	// Should return empty for an unmatched ref without panicking
+	got = resolveParameterValue("Missing", params)
+	if got != "" {
+		t.Errorf("resolveParameterValue() = %q, want %q", got, "")
+	}
+}
+
+// TestResolveParameterValue_NilPointerValue verifies that resolveParameterValue
+// does not panic when ParameterValue is nil and ResolvedValue is also nil.
+func TestResolveParameterValue_NilPointerValue(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: aws.String("EmptyParam"), ParameterValue: nil, ResolvedValue: nil},
+	}
+	got := resolveParameterValue("EmptyParam", params)
+	if got != "" {
+		t.Errorf("resolveParameterValue() = %q, want %q", got, "")
+	}
+}
+
+// TestStringPointer_NilParameterKeyAndValue verifies that stringPointer
+// does not panic when parameter entries have nil ParameterKey or ParameterValue fields.
+func TestStringPointer_NilParameterKeyAndValue(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: nil, ParameterValue: aws.String("should-skip")},
+		{ParameterKey: aws.String("GateParam"), ParameterValue: nil, ResolvedValue: nil},
+		{ParameterKey: aws.String("ValidParam"), ParameterValue: aws.String("resolved-val")},
+	}
+	logicalToPhysical := map[string]string{}
+
+	tests := []struct {
+		name  string
+		props map[string]any
+		want  *string
+	}{
+		{
+			name: "Ref to param with nil key is skipped, valid param resolves",
+			props: map[string]any{
+				"GatewayId": map[string]any{"Ref": "ValidParam"},
+			},
+			want: aws.String("resolved-val"),
+		},
+		{
+			name: "Ref to param with nil ParameterValue returns empty",
+			props: map[string]any{
+				"GatewayId": map[string]any{"Ref": "GateParam"},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stringPointer(tt.props, params, logicalToPhysical, "GatewayId")
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("stringPointer() = %v, want nil", *got)
+				}
+			} else if got == nil || *got != *tt.want {
+				t.Errorf("stringPointer() = %v, want %v", got, *tt.want)
+			}
+		})
+	}
+}
+
+// TestRouteResourceToRoute_NilParameterFields verifies that RouteResourceToRoute
+// does not panic when parameters contain nil ParameterKey or ParameterValue.
+func TestRouteResourceToRoute_NilParameterFields(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: nil, ParameterValue: aws.String("should-skip")},
+		{ParameterKey: aws.String("GateParam"), ParameterValue: aws.String("igw-123")},
+	}
+	logical := map[string]string{}
+
+	resource := CfnTemplateResource{
+		Type: "AWS::EC2::Route",
+		Properties: map[string]any{
+			"DestinationCidrBlock": "10.0.0.0/8",
+			"GatewayId":            map[string]any{"Ref": "GateParam"},
+		},
+	}
+
+	got := RouteResourceToRoute(resource, params, logical)
+	if got.GatewayId == nil || *got.GatewayId != "igw-123" {
+		t.Errorf("RouteResourceToRoute().GatewayId = %v, want igw-123", got.GatewayId)
+	}
+}

--- a/lib/tgw_routetables.go
+++ b/lib/tgw_routetables.go
@@ -256,10 +256,13 @@ func extractStringProperty(array map[string]any, params []cfntypes.Parameter, lo
 				result = logicalToPhysical[refname]
 			} else {
 				for _, parameter := range params {
+					if parameter.ParameterKey == nil {
+						continue
+					}
 					if *parameter.ParameterKey == refname {
 						if parameter.ResolvedValue != nil {
 							result = *parameter.ResolvedValue
-						} else {
+						} else if parameter.ParameterValue != nil {
 							result = *parameter.ParameterValue
 						}
 					}

--- a/lib/tgw_routetables_test.go
+++ b/lib/tgw_routetables_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	cfntypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/smithy-go"
@@ -290,5 +291,75 @@ func TestGetTransitGatewayRouteTableRoutes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestExtractStringProperty_NilParameterKeyAndValue verifies that extractStringProperty
+// does not panic when parameter entries have nil ParameterKey or ParameterValue fields.
+func TestExtractStringProperty_NilParameterKeyAndValue(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: nil, ParameterValue: aws.String("should-skip")},
+		{ParameterKey: aws.String("CIDRParam"), ParameterValue: nil, ResolvedValue: nil},
+		{ParameterKey: aws.String("ValidParam"), ParameterValue: aws.String("10.0.0.0/8")},
+	}
+	logicalToPhysical := map[string]string{}
+
+	tests := []struct {
+		name  string
+		props map[string]any
+		key   string
+		want  *string
+	}{
+		{
+			name: "Ref to param with nil key is skipped, valid param resolves",
+			props: map[string]any{
+				"DestinationCidrBlock": map[string]any{"Ref": "ValidParam"},
+			},
+			key:  "DestinationCidrBlock",
+			want: aws.String("10.0.0.0/8"),
+		},
+		{
+			name: "Ref to param with nil ParameterValue returns nil",
+			props: map[string]any{
+				"DestinationCidrBlock": map[string]any{"Ref": "CIDRParam"},
+			},
+			key:  "DestinationCidrBlock",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractStringProperty(tt.props, params, logicalToPhysical, tt.key)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("extractStringProperty() = %v, want nil", *got)
+				}
+			} else if got == nil || *got != *tt.want {
+				t.Errorf("extractStringProperty() = %v, want %v", got, *tt.want)
+			}
+		})
+	}
+}
+
+// TestTGWRouteResourceToTGWRoute_NilParameterFields verifies that TGWRouteResourceToTGWRoute
+// does not panic when parameters contain nil ParameterKey or ParameterValue.
+func TestTGWRouteResourceToTGWRoute_NilParameterFields(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: nil, ParameterValue: aws.String("should-skip")},
+		{ParameterKey: aws.String("CIDRParam"), ParameterValue: aws.String("172.16.0.0/12")},
+	}
+	logicalToPhysical := map[string]string{}
+
+	resource := CfnTemplateResource{
+		Type: "AWS::EC2::TransitGatewayRoute",
+		Properties: map[string]any{
+			"DestinationCidrBlock": map[string]any{"Ref": "CIDRParam"},
+		},
+	}
+
+	got := TGWRouteResourceToTGWRoute(resource, params, logicalToPhysical)
+	if got.DestinationCidrBlock == nil || *got.DestinationCidrBlock != "172.16.0.0/12" {
+		t.Errorf("TGWRouteResourceToTGWRoute().DestinationCidrBlock = %v, want 172.16.0.0/12", got.DestinationCidrBlock)
 	}
 }

--- a/specs/bugfixes/nil-cfn-pointers/report.md
+++ b/specs/bugfixes/nil-cfn-pointers/report.md
@@ -1,0 +1,90 @@
+# Bugfix Report: nil-cfn-pointers
+
+**Date:** 2026-04-14
+**Status:** Fixed
+
+## Description of the Issue
+
+Fog panics with a nil pointer dereference when CloudFormation returns parameter entries that have nil `ParameterKey` or `ParameterValue` pointers. This can happen during drift detection and template route processing when AWS returns incomplete parameter data.
+
+**Reproduction steps:**
+1. Have a CloudFormation stack with parameters where AWS returns a parameter entry with a nil `ParameterKey` or `ParameterValue` pointer
+2. Run fog drift detection or template route comparison
+3. Observe a panic: `runtime error: invalid memory address or nil pointer dereference`
+
+**Impact:** Crash (panic) during drift detection or route table comparison. Any stack with such parameter entries becomes unusable with fog.
+
+## Investigation Summary
+
+Systematic review of all parameter iteration loops in `lib/template.go` and `lib/tgw_routetables.go`.
+
+- **Symptoms examined:** Nil pointer dereference panic in `resolveParameterValue`
+- **Code inspected:** `resolveParameterValue`, `stringPointer` (both in `lib/template.go`), and `extractStringProperty` (in `lib/tgw_routetables.go`)
+- **Hypotheses tested:** All three functions iterate over `[]cfntypes.Parameter` and dereference pointer fields without nil guards
+
+## Discovered Root Cause
+
+Three functions dereference `*parameter.ParameterKey` and `*parameter.ParameterValue` without checking for nil first:
+
+1. `resolveParameterValue` (template.go:465) — dereferences `*parameter.ParameterKey` directly
+2. `stringPointer` (template.go:600) — dereferences `*parameter.ParameterKey` and `*parameter.ParameterValue`
+3. `extractStringProperty` (tgw_routetables.go) — dereferences `*parameter.ParameterKey` and `*parameter.ParameterValue`
+
+**Defect type:** Missing nil validation
+
+**Why it occurred:** The AWS SDK v2 CloudFormation types use `*string` for ParameterKey and ParameterValue, meaning they can be nil. The code assumed these would always be populated.
+
+**Contributing factors:** The AWS SDK uses pointer types for optional fields. While these fields are typically populated, there's no contract guaranteeing non-nil values.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/template.go:resolveParameterValue` — skip parameter entries with nil `ParameterKey`; return empty if matched key has nil `ResolvedValue` and nil `ParameterValue`
+- `lib/template.go:stringPointer` — skip parameter entries with nil `ParameterKey`; guard `ParameterValue` dereference with nil check
+- `lib/tgw_routetables.go:extractStringProperty` — skip parameter entries with nil `ParameterKey`; guard `ParameterValue` dereference with nil check
+
+**Approach rationale:** Defensive nil checks before every pointer dereference. Entries with nil keys are skipped (they cannot match any reference name). Entries with nil values are treated as unresolvable (return empty string).
+
+**Alternatives considered:**
+- Filtering parameters at a higher level — not chosen because it would require changes to many callers and the defensive checks are simple and localized.
+
+## Regression Test
+
+**Test file:** `lib/template_test.go`, `lib/tgw_routetables_test.go`
+**Test names:**
+- `TestResolveParameterValue_NilPointerKey`
+- `TestResolveParameterValue_NilPointerValue`
+- `TestStringPointer_NilParameterKeyAndValue`
+- `TestRouteResourceToRoute_NilParameterFields`
+- `TestExtractStringProperty_NilParameterKeyAndValue`
+- `TestTGWRouteResourceToTGWRoute_NilParameterFields`
+
+**What it verifies:** That nil `ParameterKey` and `ParameterValue` fields do not cause panics, and that valid parameters are still resolved correctly in the presence of nil entries.
+
+**Run command:** `go test ./lib/ -run 'TestResolveParameterValue_NilPointer|TestStringPointer_NilParameter|TestRouteResourceToRoute_NilParameter|TestExtractStringProperty_NilParameter|TestTGWRouteResourceToTGWRoute_NilParameter' -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/template.go` | Add nil guards in `resolveParameterValue` and `stringPointer` |
+| `lib/tgw_routetables.go` | Add nil guards in `extractStringProperty` |
+| `lib/template_test.go` | Add regression tests for nil parameter fields |
+| `lib/tgw_routetables_test.go` | Add regression tests for nil parameter fields |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Always nil-check AWS SDK pointer fields before dereferencing
+- Consider adding a linter rule or code review checklist item for AWS SDK pointer dereferences
+
+## Related
+
+- Transit ticket: T-775


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic when CloudFormation returns parameter entries with nil `ParameterKey` or `ParameterValue` pointers during drift detection and template route processing.

## Root Cause

Three functions iterate over `[]cfntypes.Parameter` and dereference pointer fields without nil guards:
- `resolveParameterValue` in `lib/template.go`
- `stringPointer` in `lib/template.go`
- `extractStringProperty` in `lib/tgw_routetables.go`

## Fix

Added nil checks before every `ParameterKey` and `ParameterValue` dereference:
- Skip entries with nil `ParameterKey` (cannot match any ref name)
- Guard `ParameterValue` with nil check (treat as unresolvable)

## Testing

- 6 new regression tests covering nil pointer scenarios for all three functions
- Full test suite passes with zero regressions
- `golangci-lint run` clean

## Report

See `specs/bugfixes/nil-cfn-pointers/report.md` for full investigation details.

Resolves T-775