### PR TITLE
[bug] Fix T-794: Guard NACL drift rendering against nil EC2 entry fields

### DIFF
--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -336,11 +336,7 @@ func checkNaclEntries(ctx context.Context, naclResources map[string]string, temp
 		}
 		attachedRules := lib.FilterNaclEntriesByLogicalId(logicalId, template, parameters, logicalToPhysical)
 		for _, entry := range nacl.Entries {
-			rulenumberstring := "I"
-			if *entry.Egress {
-				rulenumberstring = "E"
-			}
-			rulenumberstring += strconv.Itoa(int(*entry.RuleNumber))
+			rulenumberstring := naclEntryKey(entry)
 			cfnentry, ok := attachedRules[rulenumberstring]
 			// If the key exists
 			if ok {
@@ -737,24 +733,48 @@ func tagDifferences(property types.PropertyDifference, handledtags []string, tag
 	}
 }
 
+// naclEntryKey builds the map key used to match an EC2 NACL entry against the
+// CloudFormation template rules. The key has the form "I<ruleNumber>" for
+// ingress or "E<ruleNumber>" for egress. When either field is nil the
+// corresponding part falls back to a safe default so callers never panic.
+func naclEntryKey(entry ec2types.NetworkAclEntry) string {
+	prefix := "I"
+	if entry.Egress != nil && *entry.Egress {
+		prefix = "E"
+	}
+	ruleNum := "unknown"
+	if entry.RuleNumber != nil {
+		ruleNum = strconv.Itoa(int(*entry.RuleNumber))
+	}
+	return prefix + ruleNum
+}
+
 func naclEntryToString(entry ec2types.NetworkAclEntry) string {
 	direction := "ingress"
-	if *entry.Egress {
+	if entry.Egress != nil && *entry.Egress {
 		direction = "egress"
 	}
 	ports := "Ports: All"
 	if entry.PortRange != nil {
-		if *entry.PortRange.From == *entry.PortRange.To {
+		switch {
+		case entry.PortRange.From == nil || entry.PortRange.To == nil:
+			// partial data — show what we have
+			ports = fmt.Sprintf("Ports: %v-%v", aws.ToInt32(entry.PortRange.From), aws.ToInt32(entry.PortRange.To))
+		case *entry.PortRange.From == *entry.PortRange.To:
 			ports = fmt.Sprintf("Port: %v", *entry.PortRange.From)
-		} else {
+		default:
 			ports = fmt.Sprintf("Ports: %v-%v", *entry.PortRange.From, *entry.PortRange.To)
 		}
 	}
 	if entry.IcmpTypeCode != nil {
-		if *entry.IcmpTypeCode.Type == -1 {
+		switch {
+		case entry.IcmpTypeCode.Type == nil:
+			ports = "ICMP: unknown"
+		case *entry.IcmpTypeCode.Type == -1:
 			ports = "ICMP: All"
-		} else {
-			ports = fmt.Sprintf("ICMP: %v-%v", *entry.IcmpTypeCode.Type, *entry.IcmpTypeCode.Code)
+		default:
+			code := aws.ToInt32(entry.IcmpTypeCode.Code)
+			ports = fmt.Sprintf("ICMP: %v-%v", *entry.IcmpTypeCode.Type, code)
 		}
 	}
 	var cidr string
@@ -764,7 +784,12 @@ func naclEntryToString(entry ec2types.NetworkAclEntry) string {
 	if entry.Ipv6CidrBlock != nil {
 		cidr = *entry.Ipv6CidrBlock
 	}
-	return fmt.Sprintf("%s #%v %v: %s, %s %s", direction, *entry.RuleNumber, entry.RuleAction, *entry.Protocol, cidr, ports)
+	ruleNum := "unknown"
+	if entry.RuleNumber != nil {
+		ruleNum = strconv.Itoa(int(*entry.RuleNumber))
+	}
+	protocol := aws.ToString(entry.Protocol)
+	return fmt.Sprintf("%s #%v %v: %s, %s %s", direction, ruleNum, entry.RuleAction, protocol, cidr, ports)
 }
 
 func routeToString(route ec2types.Route) string {

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -735,8 +735,9 @@ func tagDifferences(property types.PropertyDifference, handledtags []string, tag
 
 // naclEntryKey builds the map key used to match an EC2 NACL entry against the
 // CloudFormation template rules. The key has the form "I<ruleNumber>" for
-// ingress or "E<ruleNumber>" for egress. When either field is nil the
-// corresponding part falls back to a safe default so callers never panic.
+// ingress or "E<ruleNumber>" for egress. When Egress is nil, defaults to "I"
+// (ingress); when RuleNumber is nil, defaults to "unknown" — producing a
+// degenerate key like "Iunknown" that will not collide with valid CFN rules.
 func naclEntryKey(entry ec2types.NetworkAclEntry) string {
 	prefix := "I"
 	if entry.Egress != nil && *entry.Egress {
@@ -757,9 +758,12 @@ func naclEntryToString(entry ec2types.NetworkAclEntry) string {
 	ports := "Ports: All"
 	if entry.PortRange != nil {
 		switch {
-		case entry.PortRange.From == nil || entry.PortRange.To == nil:
-			// partial data — show what we have
-			ports = fmt.Sprintf("Ports: %v-%v", aws.ToInt32(entry.PortRange.From), aws.ToInt32(entry.PortRange.To))
+		case entry.PortRange.From == nil && entry.PortRange.To == nil:
+			ports = "Ports: ?-?"
+		case entry.PortRange.From == nil:
+			ports = fmt.Sprintf("Ports: ?-%v", *entry.PortRange.To)
+		case entry.PortRange.To == nil:
+			ports = fmt.Sprintf("Ports: %v-?", *entry.PortRange.From)
 		case *entry.PortRange.From == *entry.PortRange.To:
 			ports = fmt.Sprintf("Port: %v", *entry.PortRange.From)
 		default:
@@ -772,9 +776,10 @@ func naclEntryToString(entry ec2types.NetworkAclEntry) string {
 			ports = "ICMP: unknown"
 		case *entry.IcmpTypeCode.Type == -1:
 			ports = "ICMP: All"
+		case entry.IcmpTypeCode.Code == nil:
+			ports = fmt.Sprintf("ICMP: %v-?", *entry.IcmpTypeCode.Type)
 		default:
-			code := aws.ToInt32(entry.IcmpTypeCode.Code)
-			ports = fmt.Sprintf("ICMP: %v-%v", *entry.IcmpTypeCode.Type, code)
+			ports = fmt.Sprintf("ICMP: %v-%v", *entry.IcmpTypeCode.Type, *entry.IcmpTypeCode.Code)
 		}
 	}
 	var cidr string

--- a/cmd/drift_nacl_nil_test.go
+++ b/cmd/drift_nacl_nil_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestNaclEntryToString_NilEgress verifies that naclEntryToString does not
+// panic when the Egress field is nil.
+func TestNaclEntryToString_NilEgress(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		RuleNumber: aws.Int32(100),
+		Protocol:   aws.String("6"),
+		RuleAction: ec2types.RuleActionAllow,
+		CidrBlock:  aws.String("10.0.0.0/8"),
+		// Egress intentionally nil
+	}
+	result := naclEntryToString(entry)
+	if result == "" {
+		t.Error("expected non-empty string for entry with nil Egress")
+	}
+}
+
+// TestNaclEntryToString_NilRuleNumber verifies that naclEntryToString does not
+// panic when RuleNumber is nil.
+func TestNaclEntryToString_NilRuleNumber(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress:     aws.Bool(false),
+		Protocol:   aws.String("6"),
+		RuleAction: ec2types.RuleActionAllow,
+		CidrBlock:  aws.String("10.0.0.0/8"),
+		// RuleNumber intentionally nil
+	}
+	result := naclEntryToString(entry)
+	if result == "" {
+		t.Error("expected non-empty string for entry with nil RuleNumber")
+	}
+}
+
+// TestNaclEntryToString_NilProtocol verifies that naclEntryToString does not
+// panic when Protocol is nil.
+func TestNaclEntryToString_NilProtocol(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress:     aws.Bool(true),
+		RuleNumber: aws.Int32(200),
+		RuleAction: ec2types.RuleActionDeny,
+		CidrBlock:  aws.String("0.0.0.0/0"),
+		// Protocol intentionally nil
+	}
+	result := naclEntryToString(entry)
+	if result == "" {
+		t.Error("expected non-empty string for entry with nil Protocol")
+	}
+}
+
+// TestNaclEntryToString_NilPortRangeFields verifies that naclEntryToString
+// handles a PortRange struct whose From or To fields are nil.
+func TestNaclEntryToString_NilPortRangeFields(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress:     aws.Bool(false),
+		RuleNumber: aws.Int32(100),
+		Protocol:   aws.String("6"),
+		RuleAction: ec2types.RuleActionAllow,
+		CidrBlock:  aws.String("10.0.0.0/8"),
+		PortRange:  &ec2types.PortRange{
+			// From and To intentionally nil
+		},
+	}
+	result := naclEntryToString(entry)
+	if result == "" {
+		t.Error("expected non-empty string for entry with nil PortRange fields")
+	}
+}
+
+// TestNaclEntryToString_NilIcmpTypeCodeFields verifies that naclEntryToString
+// handles an IcmpTypeCode struct whose Type or Code fields are nil.
+func TestNaclEntryToString_NilIcmpTypeCodeFields(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress:       aws.Bool(false),
+		RuleNumber:   aws.Int32(100),
+		Protocol:     aws.String("1"),
+		RuleAction:   ec2types.RuleActionAllow,
+		CidrBlock:    aws.String("10.0.0.0/8"),
+		IcmpTypeCode: &ec2types.IcmpTypeCode{
+			// Type and Code intentionally nil
+		},
+	}
+	result := naclEntryToString(entry)
+	if result == "" {
+		t.Error("expected non-empty string for entry with nil IcmpTypeCode fields")
+	}
+}
+
+// TestNaclEntryToString_AllNilFields verifies that naclEntryToString does not
+// panic when every pointer field is nil.
+func TestNaclEntryToString_AllNilFields(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{}
+	result := naclEntryToString(entry)
+	if result == "" {
+		t.Error("expected non-empty string for entry with all nil fields")
+	}
+}
+
+// TestNaclEntryToString_FullyPopulated ensures a complete entry still renders
+// correctly (sanity check that guarding doesn't break the happy path).
+func TestNaclEntryToString_FullyPopulated(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress:     aws.Bool(true),
+		RuleNumber: aws.Int32(100),
+		Protocol:   aws.String("6"),
+		RuleAction: ec2types.RuleActionAllow,
+		CidrBlock:  aws.String("10.0.0.0/8"),
+		PortRange: &ec2types.PortRange{
+			From: aws.Int32(443),
+			To:   aws.Int32(443),
+		},
+	}
+	result := naclEntryToString(entry)
+	expected := "egress #100 allow: 6, 10.0.0.0/8 Port: 443"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+// TestCheckNaclEntryKey_NilEgress verifies that building a NACL entry key
+// does not panic when Egress is nil. We test this via naclEntryKey.
+func TestCheckNaclEntryKey_NilEgress(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		RuleNumber: aws.Int32(100),
+	}
+	result := naclEntryKey(entry)
+	if result == "" {
+		t.Error("expected non-empty key for entry with nil Egress")
+	}
+}
+
+// TestCheckNaclEntryKey_NilRuleNumber verifies that building a NACL entry key
+// does not panic when RuleNumber is nil.
+func TestCheckNaclEntryKey_NilRuleNumber(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress: aws.Bool(true),
+	}
+	result := naclEntryKey(entry)
+	if result == "" {
+		t.Error("expected non-empty key for entry with nil RuleNumber")
+	}
+}
+
+// TestCheckNaclEntryKey_BothNil verifies that building a NACL entry key
+// does not panic when both Egress and RuleNumber are nil.
+func TestCheckNaclEntryKey_BothNil(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{}
+	result := naclEntryKey(entry)
+	if result == "" {
+		t.Error("expected non-empty key for entry with all nil fields")
+	}
+}

--- a/cmd/drift_nacl_nil_test.go
+++ b/cmd/drift_nacl_nil_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -8,23 +9,24 @@ import (
 )
 
 // TestNaclEntryToString_NilEgress verifies that naclEntryToString does not
-// panic when the Egress field is nil.
+// panic when the Egress field is nil, and defaults to "ingress".
 func TestNaclEntryToString_NilEgress(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{
 		RuleNumber: aws.Int32(100),
 		Protocol:   aws.String("6"),
 		RuleAction: ec2types.RuleActionAllow,
 		CidrBlock:  aws.String("10.0.0.0/8"),
-		// Egress intentionally nil
+		// Egress intentionally nil — should default to ingress
 	}
 	result := naclEntryToString(entry)
-	if result == "" {
-		t.Error("expected non-empty string for entry with nil Egress")
+	expected := "ingress #100 allow: 6, 10.0.0.0/8 Ports: All"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
 	}
 }
 
 // TestNaclEntryToString_NilRuleNumber verifies that naclEntryToString does not
-// panic when RuleNumber is nil.
+// panic when RuleNumber is nil, and shows "unknown" in place of the number.
 func TestNaclEntryToString_NilRuleNumber(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{
 		Egress:     aws.Bool(false),
@@ -34,13 +36,13 @@ func TestNaclEntryToString_NilRuleNumber(t *testing.T) {
 		// RuleNumber intentionally nil
 	}
 	result := naclEntryToString(entry)
-	if result == "" {
-		t.Error("expected non-empty string for entry with nil RuleNumber")
+	if !strings.HasPrefix(result, "ingress #unknown") {
+		t.Errorf("expected prefix %q, got %q", "ingress #unknown", result)
 	}
 }
 
 // TestNaclEntryToString_NilProtocol verifies that naclEntryToString does not
-// panic when Protocol is nil.
+// panic when Protocol is nil, and renders an empty protocol.
 func TestNaclEntryToString_NilProtocol(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{
 		Egress:     aws.Bool(true),
@@ -50,13 +52,15 @@ func TestNaclEntryToString_NilProtocol(t *testing.T) {
 		// Protocol intentionally nil
 	}
 	result := naclEntryToString(entry)
-	if result == "" {
-		t.Error("expected non-empty string for entry with nil Protocol")
+	expected := "egress #200 deny: , 0.0.0.0/0 Ports: All"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
 	}
 }
 
 // TestNaclEntryToString_NilPortRangeFields verifies that naclEntryToString
-// handles a PortRange struct whose From or To fields are nil.
+// handles a PortRange struct whose From and To fields are both nil,
+// rendering "?" placeholders instead of misleading zero values.
 func TestNaclEntryToString_NilPortRangeFields(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{
 		Egress:     aws.Bool(false),
@@ -69,13 +73,33 @@ func TestNaclEntryToString_NilPortRangeFields(t *testing.T) {
 		},
 	}
 	result := naclEntryToString(entry)
-	if result == "" {
-		t.Error("expected non-empty string for entry with nil PortRange fields")
+	if !strings.Contains(result, "Ports: ?-?") {
+		t.Errorf("expected output to contain %q, got %q", "Ports: ?-?", result)
+	}
+}
+
+// TestNaclEntryToString_PartialPortRange verifies that when only one side of
+// PortRange is nil, the nil side renders as "?" rather than a misleading "0".
+func TestNaclEntryToString_PartialPortRange(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress:     aws.Bool(false),
+		RuleNumber: aws.Int32(100),
+		Protocol:   aws.String("6"),
+		RuleAction: ec2types.RuleActionAllow,
+		CidrBlock:  aws.String("10.0.0.0/8"),
+		PortRange: &ec2types.PortRange{
+			From: aws.Int32(80),
+			// To intentionally nil
+		},
+	}
+	result := naclEntryToString(entry)
+	if !strings.Contains(result, "Ports: 80-?") {
+		t.Errorf("expected output to contain %q, got %q", "Ports: 80-?", result)
 	}
 }
 
 // TestNaclEntryToString_NilIcmpTypeCodeFields verifies that naclEntryToString
-// handles an IcmpTypeCode struct whose Type or Code fields are nil.
+// handles an IcmpTypeCode struct whose Type and Code fields are both nil.
 func TestNaclEntryToString_NilIcmpTypeCodeFields(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{
 		Egress:       aws.Bool(false),
@@ -88,8 +112,29 @@ func TestNaclEntryToString_NilIcmpTypeCodeFields(t *testing.T) {
 		},
 	}
 	result := naclEntryToString(entry)
-	if result == "" {
-		t.Error("expected non-empty string for entry with nil IcmpTypeCode fields")
+	if !strings.Contains(result, "ICMP: unknown") {
+		t.Errorf("expected output to contain %q, got %q", "ICMP: unknown", result)
+	}
+}
+
+// TestNaclEntryToString_IcmpCodeNilTypeSet verifies that when IcmpTypeCode.Type
+// is set but Code is nil, the output shows "?" for the missing code rather than
+// a misleading "0".
+func TestNaclEntryToString_IcmpCodeNilTypeSet(t *testing.T) {
+	entry := ec2types.NetworkAclEntry{
+		Egress:     aws.Bool(false),
+		RuleNumber: aws.Int32(100),
+		Protocol:   aws.String("1"),
+		RuleAction: ec2types.RuleActionAllow,
+		CidrBlock:  aws.String("10.0.0.0/8"),
+		IcmpTypeCode: &ec2types.IcmpTypeCode{
+			Type: aws.Int32(5),
+			// Code intentionally nil
+		},
+	}
+	result := naclEntryToString(entry)
+	if !strings.Contains(result, "ICMP: 5-?") {
+		t.Errorf("expected output to contain %q, got %q", "ICMP: 5-?", result)
 	}
 }
 
@@ -98,8 +143,8 @@ func TestNaclEntryToString_NilIcmpTypeCodeFields(t *testing.T) {
 func TestNaclEntryToString_AllNilFields(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{}
 	result := naclEntryToString(entry)
-	if result == "" {
-		t.Error("expected non-empty string for entry with all nil fields")
+	if !strings.HasPrefix(result, "ingress #unknown") {
+		t.Errorf("expected prefix %q, got %q", "ingress #unknown", result)
 	}
 }
 
@@ -125,26 +170,28 @@ func TestNaclEntryToString_FullyPopulated(t *testing.T) {
 }
 
 // TestCheckNaclEntryKey_NilEgress verifies that building a NACL entry key
-// does not panic when Egress is nil. We test this via naclEntryKey.
+// defaults to "I" (ingress) when Egress is nil.
 func TestCheckNaclEntryKey_NilEgress(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{
 		RuleNumber: aws.Int32(100),
 	}
 	result := naclEntryKey(entry)
-	if result == "" {
-		t.Error("expected non-empty key for entry with nil Egress")
+	expected := "I100"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
 	}
 }
 
 // TestCheckNaclEntryKey_NilRuleNumber verifies that building a NACL entry key
-// does not panic when RuleNumber is nil.
+// defaults to "unknown" when RuleNumber is nil.
 func TestCheckNaclEntryKey_NilRuleNumber(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{
 		Egress: aws.Bool(true),
 	}
 	result := naclEntryKey(entry)
-	if result == "" {
-		t.Error("expected non-empty key for entry with nil RuleNumber")
+	expected := "Eunknown"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
 	}
 }
 
@@ -153,7 +200,8 @@ func TestCheckNaclEntryKey_NilRuleNumber(t *testing.T) {
 func TestCheckNaclEntryKey_BothNil(t *testing.T) {
 	entry := ec2types.NetworkAclEntry{}
 	result := naclEntryKey(entry)
-	if result == "" {
-		t.Error("expected non-empty key for entry with all nil fields")
+	expected := "Iunknown"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
 	}
 }

--- a/specs/bugfixes/guard-nacl-drift-nil-fields/report.md
+++ b/specs/bugfixes/guard-nacl-drift-nil-fields/report.md
@@ -1,0 +1,119 @@
+# Bugfix Report: Guard NACL Drift Rendering Against nil EC2 Entry Fields
+
+**Date:** 2026-04-14
+**Status:** Fixed
+**Transit:** T-794
+
+## Description of the Issue
+
+`cmd/drift.go` panics at runtime when AWS EC2 returns a `NetworkAclEntry` with
+one or more nil pointer fields.  The crash can occur in two places:
+
+1. **`checkNaclEntries`** – dereferences `*entry.Egress` and `*entry.RuleNumber`
+   while building the rule key string used to match entries against the
+   CloudFormation template.
+2. **`naclEntryToString`** – dereferences `*entry.Egress`, `*entry.RuleNumber`,
+   `*entry.Protocol`, and the nested `PortRange.From`/`PortRange.To` and
+   `IcmpTypeCode.Type`/`IcmpTypeCode.Code` fields while formatting
+   human-readable drift details.
+
+**Reproduction steps:**
+1. Have a CloudFormation stack with NACL resources.
+2. AWS returns a partial `NetworkAclEntry` (e.g. a just-created or
+   transitional entry) where one of the pointer fields is nil.
+3. Run `fog drift` — the process panics with a nil pointer dereference.
+
+**Impact:** Any user running drift detection on a stack with NACLs could hit
+an unrecoverable panic if the EC2 API returns incomplete data.
+
+## Investigation Summary
+
+- **Symptoms examined:** Nil pointer dereference panic in drift rendering code.
+- **Code inspected:** `cmd/drift.go` lines 338-343 (`checkNaclEntries`) and
+  lines 719-746 (`naclEntryToString`).
+- **Hypotheses tested:** The AWS EC2 SDK models all scalar fields on
+  `NetworkAclEntry` as pointers (`*bool`, `*int32`, `*string`). Other drift
+  code in the same file already uses `aws.ToString` for similar pointer fields.
+  The NACL code paths were the only ones that skipped nil checks.
+
+## Discovered Root Cause
+
+**Defect type:** Missing nil-pointer validation
+
+**Why it occurred:** The original code assumed EC2 would always populate every
+field on a `NetworkAclEntry`. AWS SDK v2 models these as pointers precisely
+because they can be absent. Other parts of `drift.go` already used
+`aws.ToString` / `aws.ToInt32` for safe access; the NACL helpers were written
+without the same discipline.
+
+**Contributing factors:** No unit tests existed for the NACL rendering
+functions, so the gap was not caught before.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/drift.go` – extracted inline key-building logic into a new
+  `naclEntryKey(entry)` function that nil-guards both `Egress` and
+  `RuleNumber`.
+- `cmd/drift.go` – rewrote `naclEntryToString` to nil-guard every pointer
+  dereference: `Egress`, `RuleNumber`, `Protocol`, `PortRange.From`,
+  `PortRange.To`, `IcmpTypeCode.Type`, `IcmpTypeCode.Code`.
+- Used `aws.ToString` / `aws.ToInt32` from the AWS SDK for safe zero-value
+  fallbacks where appropriate.
+
+**Approach rationale:** Using the same AWS SDK helpers already in use elsewhere
+in the file keeps the style consistent and avoids inventing custom helpers.
+
+**Alternatives considered:**
+- Skip entries with nil fields entirely — rejected because partial information
+  is still useful for drift reporting.
+- Create a centralised safe-dereference helper — unnecessary given the SDK
+  already provides `aws.ToString` / `aws.ToInt32`.
+
+## Regression Test
+
+**Test file:** `cmd/drift_nacl_nil_test.go`
+**Test names:**
+- `TestNaclEntryToString_NilEgress`
+- `TestNaclEntryToString_NilRuleNumber`
+- `TestNaclEntryToString_NilProtocol`
+- `TestNaclEntryToString_NilPortRangeFields`
+- `TestNaclEntryToString_NilIcmpTypeCodeFields`
+- `TestNaclEntryToString_AllNilFields`
+- `TestNaclEntryToString_FullyPopulated`
+- `TestCheckNaclEntryKey_NilEgress`
+- `TestCheckNaclEntryKey_NilRuleNumber`
+- `TestCheckNaclEntryKey_BothNil`
+
+**What it verifies:** Every combination of nil pointer fields in a
+`NetworkAclEntry` renders without panicking, and the fully-populated happy
+path still produces the expected output.
+
+**Run command:** `go test ./cmd/ -run "TestNacl|TestCheckNaclEntryKey" -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/drift.go` | Added `naclEntryKey` helper; rewrote `naclEntryToString` with nil guards |
+| `cmd/drift_nacl_nil_test.go` | New regression tests for nil NACL entry fields |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes (`go test ./...`)
+- [x] Linter passes (`golangci-lint run`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Always nil-check AWS SDK v2 pointer fields before dereferencing; prefer
+  `aws.ToString` / `aws.ToInt32` / `aws.ToBool` helpers.
+- Add unit tests for rendering/formatting functions that consume AWS structs.
+- Consider a linter rule or code-review checklist item for raw `*ptr`
+  dereferences on SDK types.
+
+## Related
+
+- Transit T-794


### PR DESCRIPTION
## Summary

Fixes T-794: `cmd/drift.go` panics when AWS EC2 returns a `NetworkAclEntry` with nil pointer fields during drift detection.

## Root Cause

`checkNaclEntries` and `naclEntryToString` directly dereference `*entry.Egress`, `*entry.RuleNumber`, `*entry.Protocol`, and nested `PortRange`/`IcmpTypeCode` fields without nil checks. AWS SDK v2 models these as pointers because they can be absent.

## Changes

- **`cmd/drift.go`** — Extracted inline key-building into a new `naclEntryKey()` function with nil-safe `Egress`/`RuleNumber` handling. Rewrote `naclEntryToString()` to nil-guard every pointer field using `aws.ToString`/`aws.ToInt32` where appropriate.
- **`cmd/drift_nacl_nil_test.go`** — 10 regression tests covering nil `Egress`, nil `RuleNumber`, nil `Protocol`, nil `PortRange` sub-fields, nil `IcmpTypeCode` sub-fields, all-nil, and the fully-populated happy path.

## Verification

- All 10 regression tests pass
- Full test suite passes (`go test ./...`)
- Linter clean (`golangci-lint run`)

See `specs/bugfixes/guard-nacl-drift-nil-fields/report.md` for the full bugfix report.