### PR TITLE
[bug] Fix T-795: Guard managed prefix list filtering against nil EC2 fields

### DIFF
--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -389,12 +389,7 @@ func checkRouteTableRoutes(ctx context.Context, routetableResources map[string]s
 	if err != nil {
 		failWithError(err)
 	}
-	awsPrefixesSlice := make([]string, 0)
-	for _, prefixlist := range managedPrefixLists {
-		if *prefixlist.OwnerId == "AWS" {
-			awsPrefixesSlice = append(awsPrefixesSlice, *prefixlist.PrefixListId)
-		}
-	}
+	awsPrefixesSlice := awsManagedPrefixListIDs(managedPrefixLists)
 	// Specific check for NACLs
 	for logicalId, physicalId := range routetableResources {
 		rulechanges := []string{}
@@ -457,6 +452,22 @@ func checkRouteTableRoutes(ctx context.Context, routetableResources map[string]s
 			}
 		}
 	}
+}
+
+// awsManagedPrefixListIDs returns the PrefixListId values for entries
+// owned by "AWS". Entries with nil OwnerId or nil/empty PrefixListId are
+// silently skipped so that partial SDK responses don't cause a panic.
+func awsManagedPrefixListIDs(lists []ec2types.ManagedPrefixList) []string {
+	result := make([]string, 0, len(lists))
+	for _, pl := range lists {
+		if pl.OwnerId == nil || pl.PrefixListId == nil {
+			continue
+		}
+		if *pl.OwnerId == "AWS" && *pl.PrefixListId != "" {
+			result = append(result, *pl.PrefixListId)
+		}
+	}
+	return result
 }
 
 // checkTransitGatewayRouteTableRoutes verifies Transit Gateway routes and reports any differences

--- a/cmd/drift_prefix_list_test.go
+++ b/cmd/drift_prefix_list_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// TestAwsManagedPrefixListIDs_NilFields verifies that the filtering helper
+// does not panic when OwnerId or PrefixListId is nil, as can happen with
+// partial EC2 SDK responses.
+func TestAwsManagedPrefixListIDs_NilFields(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		input []ec2types.ManagedPrefixList
+		want  []string
+	}{
+		"nil_OwnerId_skipped": {
+			input: []ec2types.ManagedPrefixList{
+				{OwnerId: nil, PrefixListId: aws.String("pl-111")},
+			},
+			want: []string{},
+		},
+		"nil_PrefixListId_skipped": {
+			input: []ec2types.ManagedPrefixList{
+				{OwnerId: aws.String("AWS"), PrefixListId: nil},
+			},
+			want: []string{},
+		},
+		"both_nil_skipped": {
+			input: []ec2types.ManagedPrefixList{
+				{OwnerId: nil, PrefixListId: nil},
+			},
+			want: []string{},
+		},
+		"empty_PrefixListId_skipped": {
+			input: []ec2types.ManagedPrefixList{
+				{OwnerId: aws.String("AWS"), PrefixListId: aws.String("")},
+			},
+			want: []string{},
+		},
+		"non_aws_owner_excluded": {
+			input: []ec2types.ManagedPrefixList{
+				{OwnerId: aws.String("123456789012"), PrefixListId: aws.String("pl-222")},
+			},
+			want: []string{},
+		},
+		"aws_owned_included": {
+			input: []ec2types.ManagedPrefixList{
+				{OwnerId: aws.String("AWS"), PrefixListId: aws.String("pl-333")},
+			},
+			want: []string{"pl-333"},
+		},
+		"mixed_entries": {
+			input: []ec2types.ManagedPrefixList{
+				{OwnerId: nil, PrefixListId: aws.String("pl-nil-owner")},
+				{OwnerId: aws.String("AWS"), PrefixListId: nil},
+				{OwnerId: aws.String("AWS"), PrefixListId: aws.String("pl-good")},
+				{OwnerId: aws.String("123456789012"), PrefixListId: aws.String("pl-customer")},
+				{OwnerId: aws.String("AWS"), PrefixListId: aws.String("")},
+			},
+			want: []string{"pl-good"},
+		},
+		"empty_list": {
+			input: []ec2types.ManagedPrefixList{},
+			want:  []string{},
+		},
+		"nil_list": {
+			input: nil,
+			want:  []string{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := awsManagedPrefixListIDs(tc.input)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d IDs %v, want %d IDs %v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("index %d: got %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/specs/bugfixes/nil-prefix-list-fields/report.md
+++ b/specs/bugfixes/nil-prefix-list-fields/report.md
@@ -1,0 +1,77 @@
+# Bugfix Report: nil-prefix-list-fields
+
+**Date:** 2025-07-14
+**Status:** Fixed
+**Transit:** T-795
+
+## Description of the Issue
+
+`checkRouteTableRoutes` in `cmd/drift.go` panics when `DescribeManagedPrefixLists` returns a managed prefix list entry with a nil `OwnerId` or nil `PrefixListId`. The code dereferenced both pointer fields without nil guards, so any partial or malformed EC2 SDK response would crash drift detection.
+
+**Reproduction steps:**
+1. Run `fog drift` against a stack containing route tables.
+2. Have the EC2 API return a `ManagedPrefixList` entry where `OwnerId` or `PrefixListId` is nil.
+3. Observe a nil pointer dereference panic.
+
+**Impact:** Any partial EC2 response (or a test double with nil fields) causes drift detection to crash before producing any output.
+
+## Investigation Summary
+
+- **Symptoms examined:** Potential nil pointer dereference at `cmd/drift.go:398-399`.
+- **Code inspected:** `cmd/drift.go` (`checkRouteTableRoutes`), `lib/ec2.go` (`GetManagedPrefixLists`).
+- **Hypotheses tested:** Confirmed that EC2 SDK `ManagedPrefixList` fields (`OwnerId`, `PrefixListId`) are pointer-backed (`*string`) and can be nil.
+
+## Discovered Root Cause
+
+The inline loop at lines 397-400 dereferenced `*prefixlist.OwnerId` and `*prefixlist.PrefixListId` without checking for nil. AWS SDK v2 represents all EC2 response fields as pointers, meaning any of them can be nil in partial responses.
+
+**Defect type:** Missing nil validation
+
+**Why it occurred:** The original code assumed all fields in a `ManagedPrefixList` would always be populated by the SDK.
+
+**Contributing factors:** AWS SDK v2's pointer-heavy response types make nil dereference bugs easy to introduce when the happy-path response always has values set.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/drift.go` — Extracted inline filtering into `awsManagedPrefixListIDs` helper that guards against nil `OwnerId`, nil `PrefixListId`, and empty `PrefixListId` before appending.
+- `cmd/drift_prefix_list_test.go` — Added regression tests covering nil `OwnerId`, nil `PrefixListId`, both nil, empty `PrefixListId`, non-AWS owner, valid AWS entry, and mixed entries.
+
+**Approach rationale:** Extracting to a named helper makes the nil-guard logic independently testable and keeps `checkRouteTableRoutes` focused on route comparison.
+
+**Alternatives considered:**
+- Inline nil checks without extraction — works but harder to test in isolation.
+
+## Regression Test
+
+**Test file:** `cmd/drift_prefix_list_test.go`
+**Test name:** `TestAwsManagedPrefixListIDs_NilFields`
+
+**What it verifies:** That `awsManagedPrefixListIDs` does not panic on nil/empty fields, correctly filters AWS-owned entries, and skips entries with missing data.
+
+**Run command:** `go test ./cmd/... -run TestAwsManagedPrefixListIDs -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/drift.go` | Replaced inline filtering with `awsManagedPrefixListIDs` helper that includes nil guards |
+| `cmd/drift_prefix_list_test.go` | New regression test covering nil/empty field scenarios |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`go test ./...`)
+- [x] Linters pass (`golangci-lint run`)
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Always guard against nil when dereferencing AWS SDK v2 pointer fields.
+- Prefer extracting SDK response processing into testable helper functions.
+- Consider a project-wide lint rule or convention for SDK pointer access patterns.
+
+## Related
+
+- Transit ticket: T-795


### PR DESCRIPTION
## Bug

`checkRouteTableRoutes` in `cmd/drift.go` panicked when `DescribeManagedPrefixLists` returned a managed prefix list entry with nil `OwnerId` or nil `PrefixListId`. AWS SDK v2 represents these as `*string`, so partial responses or test doubles with nil fields caused a nil pointer dereference crash during drift detection.

## Root Cause

The inline loop at lines 397-400 dereferenced `*prefixlist.OwnerId` and `*prefixlist.PrefixListId` without nil checks.

## Fix

Extracted the filtering into an `awsManagedPrefixListIDs` helper that guards against nil `OwnerId`, nil `PrefixListId`, and empty `PrefixListId` before appending.

## Testing

- Added `TestAwsManagedPrefixListIDs_NilFields` covering nil, empty, and valid combinations
- Full test suite passes
- Linter passes

## Report

See `specs/bugfixes/nil-prefix-list-fields/report.md`

Fixes T-795