### PR TITLE
Fix T-817: Guard Deployment Failure Output Against Nil Event Timestamps

### DIFF
--- a/cmd/deploy_output.go
+++ b/cmd/deploy_output.go
@@ -188,6 +188,11 @@ func extractFailedResources(deployment *lib.DeployInfo, client lib.CloudFormatio
 
 	// Only look at events after changeset creation
 	for _, event := range events {
+		// Events without a timestamp cannot be compared against the changeset
+		// creation time — skip them rather than panic on a nil pointer.
+		if event.Timestamp == nil {
+			continue
+		}
 		if event.Timestamp.After(deployment.CapturedChangeset.CreationTime) {
 			// Check if this is a failed status
 			switch event.ResourceStatus {

--- a/cmd/deploy_output_test.go
+++ b/cmd/deploy_output_test.go
@@ -415,6 +415,60 @@ func TestExtractFailedResources(t *testing.T) {
 			}},
 			want: []FailedResource{},
 		},
+		// T-817: AWS SDK StackEvent.Timestamp is a pointer and can be nil.
+		// Events with nil timestamps cannot be ordered against the changeset
+		// creation time, so they must be skipped rather than dereferenced.
+		// Expected: nil-timestamp events are ignored; events with valid
+		// timestamps after the changeset creation time are still returned.
+		// Actual (before fix): panic from nil pointer dereference on
+		// event.Timestamp.After(...).
+		"skips events with nil timestamp": {
+			deployment: deploymentWithChangeset,
+			client: &mockStackEventsClient{events: []types.StackEvent{
+				{
+					Timestamp:            nil,
+					LogicalResourceId:    aws.String("NilTimestamp"),
+					ResourceType:         aws.String("AWS::S3::Bucket"),
+					ResourceStatus:       types.ResourceStatusCreateFailed,
+					ResourceStatusReason: aws.String("should be skipped"),
+				},
+				{
+					Timestamp:            aws.Time(failureTime),
+					LogicalResourceId:    aws.String("FailedResource"),
+					ResourceType:         aws.String("AWS::DynamoDB::Table"),
+					ResourceStatus:       types.ResourceStatusUpdateFailed,
+					ResourceStatusReason: aws.String("rolled back"),
+				},
+			}},
+			want: []FailedResource{{
+				LogicalID:      "FailedResource",
+				ResourceStatus: string(types.ResourceStatusUpdateFailed),
+				StatusReason:   "rolled back",
+				ResourceType:   "AWS::DynamoDB::Table",
+			}},
+		},
+		// T-817: Only nil-timestamp events should not panic and should
+		// produce an empty result.
+		"all events with nil timestamp yields empty slice": {
+			deployment: deploymentWithChangeset,
+			client: &mockStackEventsClient{events: []types.StackEvent{
+				{
+					Timestamp:            nil,
+					LogicalResourceId:    aws.String("NilOne"),
+					ResourceType:         aws.String("AWS::S3::Bucket"),
+					ResourceStatus:       types.ResourceStatusCreateFailed,
+					ResourceStatusReason: aws.String("no timestamp"),
+				},
+				{
+					Timestamp:            nil,
+					LogicalResourceId:    aws.String("NilTwo"),
+					ResourceType:         aws.String("AWS::Lambda::Function"),
+					ResourceStatus:       types.ResourceStatusUpdateFailed,
+					ResourceStatusReason: aws.String("also no timestamp"),
+				},
+			}},
+			want: []FailedResource{},
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
## Summary

- `cmd/deploy_output.go#extractFailedResources` called `event.Timestamp.After(...)` without checking whether `event.Timestamp` was nil, so any CloudFormation event returned with a missing timestamp panicked the entire deployment-failure reporting path.
- Fix mirrors the existing nil-safe pattern in `cmd/deploy.go` (`renderEvent`, `renderFailedEvent`): events with nil timestamps are skipped because they cannot be ordered against the captured changeset creation time.
- Adds two regression cases to `TestExtractFailedResources` (mixed and all-nil timestamps) that panicked before the fix and now pass.

## Root cause

AWS SDK v2 models `types.StackEvent.Timestamp` as `*time.Time`; partial event responses can set it to nil. `extractFailedResources` assumed it was always populated, unlike the adjacent helpers in `cmd/deploy.go` that already guard.

## Test plan

- [x] `go test ./cmd/ -run 'TestExtractFailedResources' -v`
- [x] `go test ./...`
- [x] `go vet ./...`

Resolves T-817.