### PR TITLE
Fix T-799: Guard Report Event Processing Against Nil Stack Event Fields

### DIFF
--- a/lib/stacks.go
+++ b/lib/stacks.go
@@ -712,13 +712,15 @@ func handleResourceEvent(event types.StackEvent, stackEvent StackEvent,
 	return resources, finishedEvents, failedEvents
 }
 
-// generateResourceEventName creates a unique name for a resource event
+// generateResourceEventName creates a unique name for a resource event.
+// Uses aws.ToString so nil ResourceType or LogicalResourceId pointers resolve
+// to empty strings rather than panicking.
 func generateResourceEventName(event types.StackEvent, stackEvent StackEvent,
 	finishedEvents, failedEvents []string) string {
 
 	name := fmt.Sprintf("%s-%s-%s",
-		slug.Make(*event.ResourceType),
-		*event.LogicalResourceId,
+		slug.Make(aws.ToString(event.ResourceType)),
+		aws.ToString(event.LogicalResourceId),
 		stackEvent.StartDate.Format(time.RFC3339))
 
 	if stringInSlice(name, finishedEvents) {
@@ -891,8 +893,19 @@ type ReverseEvents []types.StackEvent
 // Len returns the length of the slice
 func (a ReverseEvents) Len() int { return len(a) }
 
-// Less compares two events by timestamp
-func (a ReverseEvents) Less(i, j int) bool { return a[i].Timestamp.Before(*a[j].Timestamp) }
+// Less compares two events by timestamp. Events with nil Timestamps are
+// treated as the zero time so they sort to the beginning rather than panicking.
+func (a ReverseEvents) Less(i, j int) bool {
+	return safeEventTimestamp(a[i].Timestamp).Before(safeEventTimestamp(a[j].Timestamp))
+}
+
+// safeEventTimestamp returns the dereferenced time or the zero value when t is nil.
+func safeEventTimestamp(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
 
 // Swap swaps two elements in the slice
 func (a ReverseEvents) Swap(i, j int) { a[i], a[j] = a[j], a[i] }

--- a/lib/stacks_nil_event_fields_test.go
+++ b/lib/stacks_nil_event_fields_test.go
@@ -1,0 +1,147 @@
+package lib
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+)
+
+// TestReverseEvents_NilTimestamps verifies that sorting a slice of StackEvents
+// that contain nil Timestamp pointers does not panic (regression test for T-799).
+// Before the fix, ReverseEvents.Less dereferenced the Timestamp pointers
+// directly, causing a nil pointer dereference.
+func TestReverseEvents_NilTimestamps(t *testing.T) {
+	t.Parallel()
+
+	t1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 2, 12, 0, 0, 0, time.UTC)
+
+	tests := map[string]struct {
+		events ReverseEvents
+	}{
+		"both timestamps nil": {
+			events: ReverseEvents{
+				{Timestamp: nil},
+				{Timestamp: nil},
+			},
+		},
+		"first timestamp nil": {
+			events: ReverseEvents{
+				{Timestamp: nil},
+				{Timestamp: &t1},
+			},
+		},
+		"second timestamp nil": {
+			events: ReverseEvents{
+				{Timestamp: &t1},
+				{Timestamp: nil},
+			},
+		},
+		"mixed nil and valid": {
+			events: ReverseEvents{
+				{Timestamp: &t2},
+				{Timestamp: nil},
+				{Timestamp: &t1},
+				{Timestamp: nil},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("sort.Sort panicked on nil Timestamp: %v", r)
+				}
+			}()
+			sort.Sort(tc.events)
+		})
+	}
+}
+
+// TestGenerateResourceEventName_NilFields verifies that generateResourceEventName
+// does not panic when the StackEvent has nil ResourceType or LogicalResourceId
+// pointers (regression test for T-799).
+func TestGenerateResourceEventName_NilFields(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := map[string]struct {
+		event types.StackEvent
+	}{
+		"nil ResourceType": {
+			event: types.StackEvent{
+				ResourceType:      nil,
+				LogicalResourceId: aws.String("MyBucket"),
+			},
+		},
+		"nil LogicalResourceId": {
+			event: types.StackEvent{
+				ResourceType:      aws.String("AWS::S3::Bucket"),
+				LogicalResourceId: nil,
+			},
+		},
+		"both nil": {
+			event: types.StackEvent{
+				ResourceType:      nil,
+				LogicalResourceId: nil,
+			},
+		},
+	}
+
+	stackEvent := StackEvent{StartDate: baseTime}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("generateResourceEventName panicked on nil field: %v", r)
+				}
+			}()
+			got := generateResourceEventName(tc.event, stackEvent, nil, nil)
+			if got == "" {
+				t.Errorf("generateResourceEventName returned empty string; want a sensible fallback name")
+			}
+		})
+	}
+}
+
+// TestProcessStackEvents_NilFields verifies that processStackEvents does not
+// panic when events in the slice contain nil pointer fields (regression test
+// for T-799). This covers the end-to-end path used by GetEvents in the
+// report command.
+func TestProcessStackEvents_NilFields(t *testing.T) {
+	t.Parallel()
+
+	t1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	events := []types.StackEvent{
+		{
+			// stack-level event with valid fields to start the event group
+			LogicalResourceId: aws.String("my-stack"),
+			ResourceType:      aws.String("AWS::CloudFormation::Stack"),
+			ResourceStatus:    types.ResourceStatusCreateInProgress,
+			Timestamp:         &t1,
+		},
+		{
+			// resource event with nil ResourceType and LogicalResourceId
+			LogicalResourceId: nil,
+			ResourceType:      nil,
+			ResourceStatus:    types.ResourceStatusCreateInProgress,
+			Timestamp:         nil,
+		},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("processStackEvents panicked on nil field: %v", r)
+		}
+	}()
+	_ = processStackEvents(events, "my-stack")
+}

--- a/lib/stacks_nil_event_fields_test.go
+++ b/lib/stacks_nil_event_fields_test.go
@@ -2,6 +2,7 @@ package lib
 
 import (
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -72,19 +73,24 @@ func TestGenerateResourceEventName_NilFields(t *testing.T) {
 	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	tests := map[string]struct {
-		event types.StackEvent
+		event           types.StackEvent
+		wantContainsRT  string
+		wantContainsLID string
 	}{
 		"nil ResourceType": {
 			event: types.StackEvent{
 				ResourceType:      nil,
 				LogicalResourceId: aws.String("MyBucket"),
 			},
+			wantContainsLID: "MyBucket",
 		},
 		"nil LogicalResourceId": {
 			event: types.StackEvent{
 				ResourceType:      aws.String("AWS::S3::Bucket"),
 				LogicalResourceId: nil,
 			},
+			// ResourceType runs through slug.Make (lowercased, "::" -> "-").
+			wantContainsRT: "aws-s3-bucket",
 		},
 		"both nil": {
 			event: types.StackEvent{
@@ -105,8 +111,18 @@ func TestGenerateResourceEventName_NilFields(t *testing.T) {
 				}
 			}()
 			got := generateResourceEventName(tc.event, stackEvent, nil, nil)
-			if got == "" {
-				t.Errorf("generateResourceEventName returned empty string; want a sensible fallback name")
+			// The fallback format is "<ResourceType>-<LogicalResourceId>-<StartDate RFC3339>".
+			// Missing pointer fields become empty strings, so the timestamp suffix
+			// must always be present to make the name unique per event group.
+			wantSuffix := baseTime.Format(time.RFC3339)
+			if !strings.HasSuffix(got, wantSuffix) {
+				t.Errorf("generateResourceEventName = %q; want suffix %q", got, wantSuffix)
+			}
+			if tc.wantContainsRT != "" && !strings.Contains(got, tc.wantContainsRT) {
+				t.Errorf("generateResourceEventName = %q; want to contain ResourceType %q", got, tc.wantContainsRT)
+			}
+			if tc.wantContainsLID != "" && !strings.Contains(got, tc.wantContainsLID) {
+				t.Errorf("generateResourceEventName = %q; want to contain LogicalResourceId %q", got, tc.wantContainsLID)
 			}
 		})
 	}
@@ -120,6 +136,7 @@ func TestProcessStackEvents_NilFields(t *testing.T) {
 	t.Parallel()
 
 	t1 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 1, 12, 5, 0, 0, time.UTC)
 
 	events := []types.StackEvent{
 		{
@@ -136,6 +153,14 @@ func TestProcessStackEvents_NilFields(t *testing.T) {
 			ResourceStatus:    types.ResourceStatusCreateInProgress,
 			Timestamp:         nil,
 		},
+		{
+			// stack-level completion event to finalize the group so we can
+			// assert the group was produced without dropping events.
+			LogicalResourceId: aws.String("my-stack"),
+			ResourceType:      aws.String("AWS::CloudFormation::Stack"),
+			ResourceStatus:    types.ResourceStatusCreateComplete,
+			Timestamp:         &t2,
+		},
 	}
 
 	defer func() {
@@ -143,5 +168,12 @@ func TestProcessStackEvents_NilFields(t *testing.T) {
 			t.Fatalf("processStackEvents panicked on nil field: %v", r)
 		}
 	}()
-	_ = processStackEvents(events, "my-stack")
+	result := processStackEvents(events, "my-stack")
+	// The sequence contains a start + completion pair, so the result must
+	// contain at least one finalized event group. Without this check the test
+	// would only guard against a panic, not against the function silently
+	// dropping all events.
+	if len(result) == 0 {
+		t.Errorf("processStackEvents returned empty result; want at least one finalized event group")
+	}
 }


### PR DESCRIPTION
## Summary
- The report path (`cmd/report.go` -> `stack.GetEvents()` -> `lib.fetchAllStackEvents` / `lib.processStackEvents`) dereferenced AWS SDK pointer fields without nil checks, panicking on partial CloudFormation events.
- `ReverseEvents.Less` in `lib/stacks.go` now treats nil `Timestamp` as the zero time via a new `safeEventTimestamp` helper, mirroring the pattern from the T-756 deploy-path fix.
- `generateResourceEventName` now uses `aws.ToString` for `ResourceType` and `LogicalResourceId`, matching the idiom already used in `createNewResourceEvent`.

## Root cause
Two `ReverseEvents` implementations exist (one in `cmd/deploy.go`, one in `lib/stacks.go`). T-756 hardened only the `cmd` copy; the library version — used by the report command and any other caller of `lib.GetEvents` — kept the unsafe dereferences. `generateResourceEventName` also dereferenced pointer fields directly despite the surrounding code already modelling nil as valid (`createNewStackEvent`, `createNewResourceEvent` already guard `Timestamp`).

## Test plan
- [x] Regression tests fail before the fix and pass after: `go test ./lib/ -run 'TestReverseEvents_NilTimestamps|TestGenerateResourceEventName_NilFields|TestProcessStackEvents_NilFields' -v`
- [x] Full unit suite: `go test ./...`
- [x] Integration suite: `INTEGRATION=1 go test ./...`
- [x] `go vet ./lib/...`

## Related
- Transit: T-799
- Prior related fix: T-756 (deploy-path hardening, PR #166)