### PR TITLE
Fix T-866: EC2 Drift Filters Miss Hardcoded Physical Route and NACL IDs

### DIFF
--- a/docs/agent-notes/template-filters.md
+++ b/docs/agent-notes/template-filters.md
@@ -4,8 +4,10 @@
 
 `resourceIdMatchesLogical` in `lib/template.go` is a shared helper used by all three filter functions (`FilterNaclEntriesByLogicalId`, `FilterRoutesByLogicalId`, `FilterTGWRoutesByLogicalId`) to match a resource property value against a logical resource ID.
 
-It handles two forms of property values:
+It handles four forms of property values:
 - **String** (`"REF: LogicalName"`): strips the `REF: ` prefix and compares directly against the logical ID.
+- **String** (plain physical ID such as `"rtb-12345"` or `"acl-12345"`): after stripping any `REF: ` prefix, compares the value against `logicalToPhysical[logicalId]`. This mirrors `tgwRouteMatchesRouteTable` in `lib/tgw_routetables.go` and covers CloudFormation templates that hardcode parent resource IDs rather than using intrinsic functions. Regression tests for this case live in `lib/template_test.go` (`TestResourceIdMatchesLogical_HardcodedPhysicalId`, `TestFilterRoutesByLogicalId_HardcodedPhysicalId`, `TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId`).
+- **Map** (`{"Ref": "LogicalName"}`): compares the ref name directly against the logical ID.
 - **Map** (`{"Fn::ImportValue": "ExportName"}`): resolves both the import name and the logical ID through `logicalToPhysical`, then compares their physical IDs.
 
 ## logicalToPhysical Map

--- a/docs/agent-notes/template-filters.md
+++ b/docs/agent-notes/template-filters.md
@@ -2,13 +2,15 @@
 
 ## Key Abstraction: resourceIdMatchesLogical
 
-`resourceIdMatchesLogical` in `lib/template.go` is a shared helper used by all three filter functions (`FilterNaclEntriesByLogicalId`, `FilterRoutesByLogicalId`, `FilterTGWRoutesByLogicalId`) to match a resource property value against a logical resource ID.
+`resourceIdMatchesLogical` in `lib/template.go` is a shared helper used by `FilterNaclEntriesByLogicalId` and `FilterRoutesByLogicalId` to match a resource property value against a logical resource ID. `FilterTGWRoutesByLogicalId` uses a separate matcher, `tgwRouteMatchesRouteTable` in `lib/tgw_routetables.go`, which covers the same property formats for TGW route tables.
 
 It handles four forms of property values:
 - **String** (`"REF: LogicalName"`): strips the `REF: ` prefix and compares directly against the logical ID.
-- **String** (plain physical ID such as `"rtb-12345"` or `"acl-12345"`): after stripping any `REF: ` prefix, compares the value against `logicalToPhysical[logicalId]`. This mirrors `tgwRouteMatchesRouteTable` in `lib/tgw_routetables.go` and covers CloudFormation templates that hardcode parent resource IDs rather than using intrinsic functions. Regression tests for this case live in `lib/template_test.go` (`TestResourceIdMatchesLogical_HardcodedPhysicalId`, `TestFilterRoutesByLogicalId_HardcodedPhysicalId`, `TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId`).
+- **String** (plain physical ID such as `"rtb-12345"` or `"acl-12345"`): after stripping any `REF: ` prefix, compares the value against `logicalToPhysical[logicalId]`. This covers CloudFormation templates that hardcode parent resource IDs rather than using intrinsic functions.
 - **Map** (`{"Ref": "LogicalName"}`): compares the ref name directly against the logical ID.
 - **Map** (`{"Fn::ImportValue": "ExportName"}`): resolves both the import name and the logical ID through `logicalToPhysical`, then compares their physical IDs.
+
+Regression tests for the plain-physical-ID case are in `lib/template_test.go` (`TestResourceIdMatchesLogical_HardcodedPhysicalId`, `TestFilterRoutesByLogicalId_HardcodedPhysicalId`, `TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId`).
 
 ## logicalToPhysical Map
 

--- a/lib/template.go
+++ b/lib/template.go
@@ -322,8 +322,10 @@ func ParseTemplateString(template string, parameters *map[string]any) (CfnTempla
 }
 
 // resourceIdMatchesLogical checks whether a resource property value refers to the
-// same physical resource as logicalId. It handles three property formats:
+// same physical resource as logicalId. It handles four property formats:
 //   - string "REF: LogicalName" — the logical name is compared directly
+//   - string "phys-12345" — a literal physical ID is compared against
+//     logicalToPhysical[logicalId]
 //   - map {"Ref": "LogicalName"} — the logical name is compared directly
 //   - map {"Fn::ImportValue": "ExportName"} — the export is resolved through
 //     logicalToPhysical and compared against the physical ID of logicalId
@@ -331,7 +333,16 @@ func resourceIdMatchesLogical(prop any, logicalId string, logicalToPhysical map[
 	switch value := prop.(type) {
 	case string:
 		refId := strings.TrimPrefix(value, "REF: ")
-		return refId == logicalId
+		if refId == logicalId {
+			return true
+		}
+		// Handle plain physical ID string (e.g. "rtb-12345" or "acl-12345")
+		// by comparing against the physical ID of logicalId, mirroring
+		// tgwRouteMatchesRouteTable in lib/tgw_routetables.go.
+		if physicalId, ok := logicalToPhysical[logicalId]; ok && physicalId != "" {
+			return refId == physicalId
+		}
+		return false
 	case map[string]any:
 		// Handle {"Ref": "LogicalId"} format (raw-map / non-stringified refs)
 		if refName, ok := value["Ref"].(string); ok {

--- a/lib/template.go
+++ b/lib/template.go
@@ -336,9 +336,7 @@ func resourceIdMatchesLogical(prop any, logicalId string, logicalToPhysical map[
 		if refId == logicalId {
 			return true
 		}
-		// Handle plain physical ID string (e.g. "rtb-12345" or "acl-12345")
-		// by comparing against the physical ID of logicalId, mirroring
-		// tgwRouteMatchesRouteTable in lib/tgw_routetables.go.
+		// Plain physical ID string — compare against the mapped physical ID of logicalId.
 		if physicalId, ok := logicalToPhysical[logicalId]; ok && physicalId != "" {
 			return refId == physicalId
 		}

--- a/lib/template_test.go
+++ b/lib/template_test.go
@@ -1600,12 +1600,8 @@ func TestRouteResourceToRoute_NilParameterFields(t *testing.T) {
 }
 
 // TestFilterRoutesByLogicalId_HardcodedPhysicalId verifies that routes whose
-// RouteTableId property is supplied as a literal physical ID string (e.g.
-// "rtb-12345") are matched against the logical ID via the logicalToPhysical
-// map. Regression test for T-866: without the fix, the string branch of
-// resourceIdMatchesLogical only compares the trimmed value against the logical
-// ID and misses plain physical IDs entirely, so the route is omitted from the
-// template-side map and drift detection reports a managed route as unmanaged.
+// RouteTableId property is a literal physical ID string are matched against
+// the logical ID via the logicalToPhysical map.
 func TestFilterRoutesByLogicalId_HardcodedPhysicalId(t *testing.T) {
 	params := []cfntypes.Parameter{}
 	logicalToPhysical := map[string]string{
@@ -1648,9 +1644,8 @@ func TestFilterRoutesByLogicalId_HardcodedPhysicalId(t *testing.T) {
 }
 
 // TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId verifies that NACL
-// entries whose NetworkAclId property is supplied as a literal physical ID
-// string (e.g. "acl-12345") are matched against the logical ID via the
-// logicalToPhysical map. Regression test for T-866.
+// entries whose NetworkAclId property is a literal physical ID string are
+// matched against the logical ID via the logicalToPhysical map.
 func TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId(t *testing.T) {
 	params := []cfntypes.Parameter{}
 	logicalToPhysical := map[string]string{
@@ -1701,7 +1696,6 @@ func TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId(t *testing.T) {
 // TestResourceIdMatchesLogical_HardcodedPhysicalId verifies that
 // resourceIdMatchesLogical matches a plain physical ID string against the
 // physical ID of the logical resource via the logicalToPhysical map.
-// Regression test for T-866.
 func TestResourceIdMatchesLogical_HardcodedPhysicalId(t *testing.T) {
 	logicalToPhysical := map[string]string{
 		"MyResource": "phys-12345",
@@ -1716,6 +1710,12 @@ func TestResourceIdMatchesLogical_HardcodedPhysicalId(t *testing.T) {
 		{
 			name:      "plain physical ID string matches via logicalToPhysical",
 			prop:      "phys-12345",
+			logicalId: "MyResource",
+			want:      true,
+		},
+		{
+			name:      "REF:-prefixed physical ID still matches after trimming",
+			prop:      "REF: phys-12345",
 			logicalId: "MyResource",
 			want:      true,
 		},

--- a/lib/template_test.go
+++ b/lib/template_test.go
@@ -1598,3 +1598,147 @@ func TestRouteResourceToRoute_NilParameterFields(t *testing.T) {
 		t.Errorf("RouteResourceToRoute().GatewayId = %v, want igw-123", got.GatewayId)
 	}
 }
+
+// TestFilterRoutesByLogicalId_HardcodedPhysicalId verifies that routes whose
+// RouteTableId property is supplied as a literal physical ID string (e.g.
+// "rtb-12345") are matched against the logical ID via the logicalToPhysical
+// map. Regression test for T-866: without the fix, the string branch of
+// resourceIdMatchesLogical only compares the trimmed value against the logical
+// ID and misses plain physical IDs entirely, so the route is omitted from the
+// template-side map and drift detection reports a managed route as unmanaged.
+func TestFilterRoutesByLogicalId_HardcodedPhysicalId(t *testing.T) {
+	params := []cfntypes.Parameter{}
+	logicalToPhysical := map[string]string{
+		"MyRouteTable": "rtb-physical123",
+	}
+
+	template := CfnTemplateBody{
+		Resources: map[string]CfnTemplateResource{
+			"PhysicalIdRoute": {
+				Type: "AWS::EC2::Route",
+				Properties: map[string]any{
+					"RouteTableId":         "rtb-physical123",
+					"DestinationCidrBlock": "10.50.0.0/16",
+					"GatewayId":            "igw-abc123",
+				},
+			},
+			"UnrelatedRoute": {
+				Type: "AWS::EC2::Route",
+				Properties: map[string]any{
+					"RouteTableId":         "rtb-other999",
+					"DestinationCidrBlock": "10.99.0.0/16",
+					"GatewayId":            "igw-other",
+				},
+			},
+		},
+		Conditions: map[string]bool{},
+	}
+
+	results := FilterRoutesByLogicalId("MyRouteTable", template, params, logicalToPhysical)
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 route, got %d", len(results))
+	}
+	if _, ok := results["10.50.0.0/16"]; !ok {
+		t.Error("Expected hardcoded physical ID route (10.50.0.0/16) not found")
+	}
+	if _, ok := results["10.99.0.0/16"]; ok {
+		t.Error("Unrelated physical ID route (10.99.0.0/16) should not be included")
+	}
+}
+
+// TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId verifies that NACL
+// entries whose NetworkAclId property is supplied as a literal physical ID
+// string (e.g. "acl-12345") are matched against the logical ID via the
+// logicalToPhysical map. Regression test for T-866.
+func TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId(t *testing.T) {
+	params := []cfntypes.Parameter{}
+	logicalToPhysical := map[string]string{
+		"MyNacl": "acl-physical123",
+	}
+
+	template := CfnTemplateBody{
+		Resources: map[string]CfnTemplateResource{
+			"PhysicalIdEntry": {
+				Type: "AWS::EC2::NetworkAclEntry",
+				Properties: map[string]any{
+					"NetworkAclId": "acl-physical123",
+					"RuleNumber":   float64(100),
+					"Protocol":     "-1",
+					"RuleAction":   "allow",
+					"Egress":       false,
+					"CidrBlock":    "10.0.0.0/8",
+				},
+			},
+			"UnrelatedEntry": {
+				Type: "AWS::EC2::NetworkAclEntry",
+				Properties: map[string]any{
+					"NetworkAclId": "acl-other999",
+					"RuleNumber":   float64(200),
+					"Protocol":     "-1",
+					"RuleAction":   "allow",
+					"Egress":       false,
+					"CidrBlock":    "10.1.0.0/16",
+				},
+			},
+		},
+		Conditions: map[string]bool{},
+	}
+
+	results := FilterNaclEntriesByLogicalId("MyNacl", template, params, logicalToPhysical)
+
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 NACL entry, got %d", len(results))
+	}
+	if _, ok := results["I100"]; !ok {
+		t.Error("Expected hardcoded physical ID NACL entry (I100) not found")
+	}
+	if _, ok := results["I200"]; ok {
+		t.Error("Unrelated physical ID NACL entry (I200) should not be included")
+	}
+}
+
+// TestResourceIdMatchesLogical_HardcodedPhysicalId verifies that
+// resourceIdMatchesLogical matches a plain physical ID string against the
+// physical ID of the logical resource via the logicalToPhysical map.
+// Regression test for T-866.
+func TestResourceIdMatchesLogical_HardcodedPhysicalId(t *testing.T) {
+	logicalToPhysical := map[string]string{
+		"MyResource": "phys-12345",
+	}
+
+	tests := []struct {
+		name      string
+		prop      any
+		logicalId string
+		want      bool
+	}{
+		{
+			name:      "plain physical ID string matches via logicalToPhysical",
+			prop:      "phys-12345",
+			logicalId: "MyResource",
+			want:      true,
+		},
+		{
+			name:      "plain physical ID that does not match logical ID's physical ID",
+			prop:      "phys-other",
+			logicalId: "MyResource",
+			want:      false,
+		},
+		{
+			name:      "plain physical ID when logical ID has no physical mapping",
+			prop:      "phys-12345",
+			logicalId: "UnmappedResource",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resourceIdMatchesLogical(tt.prop, tt.logicalId, logicalToPhysical)
+			if got != tt.want {
+				t.Errorf("resourceIdMatchesLogical(%v, %q) = %v, want %v", tt.prop, tt.logicalId, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes T-866. `resourceIdMatchesLogical()` in `lib/template.go` — the shared matcher used by `FilterRoutesByLogicalId()` and `FilterNaclEntriesByLogicalId()` — handled `REF:` strings, `Ref` maps, and `Fn::ImportValue` maps, but not plain physical ID strings. Routes and NACL entries whose parent reference was a literal physical ID (e.g. `RouteTableId: rtb-12345`) were dropped from the template-side map, causing drift detection to report managed routes or NACL entries as unmanaged.

## Root Cause

The string branch of `resourceIdMatchesLogical()` only compared the trimmed value against the logical ID. It never consulted `logicalToPhysical[logicalId]`, so hardcoded physical IDs were never matched. The analogous TGW matcher (`tgwRouteMatchesRouteTable` in `lib/tgw_routetables.go`) already handles this case.

## Fix

- Extend the string branch of `resourceIdMatchesLogical()` to also compare the (trimmed) value against `logicalToPhysical[logicalId]` when that mapping is present.
- Add regression tests for the helper and both EC2 filter functions covering the hardcoded physical ID case.
- Update `docs/agent-notes/template-filters.md` to document the plain-physical-ID branch.

## Test plan

- [x] `go test ./lib -run 'TestResourceIdMatchesLogical_HardcodedPhysicalId|TestFilterRoutesByLogicalId_HardcodedPhysicalId|TestFilterNaclEntriesByLogicalId_HardcodedPhysicalId' -count=1` — fails before the fix, passes after
- [x] `go test ./...` — full unit test suite passes
- [x] `INTEGRATION=1 go test ./...` — full integration test suite passes
- [x] `go vet ./...` — clean