### PR TITLE
Fix T-881: Transit Gateway Route Drift Ignores Additional Routes

### DIFF
--- a/docs/agent-notes/tgw-drift-detection.md
+++ b/docs/agent-notes/tgw-drift-detection.md
@@ -18,6 +18,23 @@ Code that reads these properties must use a type switch or `extractStringPropert
 - `extractStringProperty` (lib/tgw_routetables.go): General-purpose helper that resolves property values from all formats. Used by `TGWRouteResourceToTGWRoute` for other properties.
 - `tgwRouteMatchesRouteTable` (lib/tgw_routetables.go): Type-safe route table ID matching supporting all property formats.
 
+## SearchTransitGatewayRoutes Truncation (T-881)
+
+`ec2.SearchTransitGatewayRoutes` does not expose a `NextToken` — it caps the
+response at 1000 routes and signals truncation via `AdditionalRoutesAvailable`.
+`GetTransitGatewayRouteTableRoutes` handles this by narrowing the query on
+`type` (static and propagated) and returning the union. If either narrowed
+call still reports additional routes available, the function returns an error
+wrapping `ErrTGWRoutesTruncated` rather than silently returning partial data.
+
+Key helpers:
+- `searchTGWRoutes` — single-call wrapper with friendly error mapping (NotFound,
+  UnauthorizedOperation, deadline). Reused by the initial call and the
+  narrowed retries.
+- `additionalRoutesAvailable` — nil-safe read of the truncation flag.
+- `ErrTGWRoutesTruncated` — sentinel for callers that want to detect the
+  post-narrowing overflow case with `errors.Is`.
+
 ## logicalToPhysical Map
 
 The `logicalToPhysical` map (built in `cmd/drift.go:separateSpecialCases`) contains both:

--- a/lib/tgw_routetables.go
+++ b/lib/tgw_routetables.go
@@ -14,34 +14,87 @@ import (
 	"github.com/aws/smithy-go"
 )
 
-// GetTransitGatewayRouteTableRoutes returns all routes for a Transit Gateway route table
+// ErrTGWRoutesTruncated is returned when SearchTransitGatewayRoutes reports
+// AdditionalRoutesAvailable=true even after narrowing the query by route type.
+// The EC2 API caps responses at 1000 routes and does not support a continuation
+// token, so when both the static and propagated splits still overflow there is
+// no further partitioning available and the result set cannot be retrieved in
+// full.
+var ErrTGWRoutesTruncated = errors.New("transit gateway route results truncated: more than 1000 routes for a single type filter")
+
+// GetTransitGatewayRouteTableRoutes returns all routes for a Transit Gateway route table.
+//
+// SearchTransitGatewayRoutes caps its response at 1000 routes and indicates
+// truncation via AdditionalRoutesAvailable rather than a continuation token.
+// When the initial state-filtered call reports additional routes available, we
+// narrow the query by route type (static and propagated) to retrieve the full
+// result set as the union of both type-filtered calls. If either narrowed call
+// still reports additional routes available, we return an error wrapping
+// ErrTGWRoutesTruncated rather than silently returning partial data.
 func GetTransitGatewayRouteTableRoutes(
 	ctx context.Context,
 	routeTableId string,
 	svc EC2SearchTransitGatewayRoutesAPI,
 ) ([]types.TransitGatewayRoute, error) {
-	// Add timeout to context for API call
+	// Add timeout to context for API call(s)
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	stateFilter := types.Filter{
+		Name:   aws.String("state"),
+		Values: []string{"active", "blackhole"},
+	}
+
+	result, err := searchTGWRoutes(ctx, svc, routeTableId, []types.Filter{stateFilter})
+	if err != nil {
+		return nil, err
+	}
+
+	if !additionalRoutesAvailable(result) {
+		return result.Routes, nil
+	}
+
+	// The single-filter response was truncated. Split by route type to cover
+	// the full result set. The union of "static" and "propagated" equals the
+	// entire set of routes in the table.
+	combined := make([]types.TransitGatewayRoute, 0, len(result.Routes))
+	for _, routeType := range []string{"static", "propagated"} {
+		typeFilter := types.Filter{
+			Name:   aws.String("type"),
+			Values: []string{routeType},
+		}
+		narrowed, err := searchTGWRoutes(ctx, svc, routeTableId, []types.Filter{stateFilter, typeFilter})
+		if err != nil {
+			return nil, err
+		}
+		if additionalRoutesAvailable(narrowed) {
+			return nil, fmt.Errorf("route table %s type=%s: %w", routeTableId, routeType, ErrTGWRoutesTruncated)
+		}
+		combined = append(combined, narrowed.Routes...)
+	}
+	return combined, nil
+}
+
+// searchTGWRoutes issues a single SearchTransitGatewayRoutes call and maps
+// AWS errors to friendlier wrapped errors. It is factored out so the narrowing
+// retry can reuse the same error-handling logic.
+func searchTGWRoutes(
+	ctx context.Context,
+	svc EC2SearchTransitGatewayRoutesAPI,
+	routeTableId string,
+	filters []types.Filter,
+) (*ec2.SearchTransitGatewayRoutesOutput, error) {
 	input := ec2.SearchTransitGatewayRoutesInput{
 		TransitGatewayRouteTableId: aws.String(routeTableId),
-		Filters: []types.Filter{
-			{
-				Name:   aws.String("state"),
-				Values: []string{"active", "blackhole"},
-			},
-		},
+		Filters:                    filters,
 	}
 
 	result, err := svc.SearchTransitGatewayRoutes(ctx, &input)
 	if err != nil {
-		// Handle context timeout
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, fmt.Errorf("API call timed out after 30 seconds: %w", err)
 		}
 
-		// Use type assertion for AWS API errors
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) {
 			switch apiErr.ErrorCode() {
@@ -55,7 +108,13 @@ func GetTransitGatewayRouteTableRoutes(
 		return nil, err
 	}
 
-	return result.Routes, nil
+	return result, nil
+}
+
+// additionalRoutesAvailable reports whether the API signalled that more routes
+// than fit in the response were available for the query.
+func additionalRoutesAvailable(result *ec2.SearchTransitGatewayRoutesOutput) bool {
+	return result != nil && result.AdditionalRoutesAvailable != nil && *result.AdditionalRoutesAvailable
 }
 
 // GetTGWRouteDestination returns the destination identifier from a Transit Gateway route

--- a/lib/tgw_routetables.go
+++ b/lib/tgw_routetables.go
@@ -44,7 +44,7 @@ func GetTransitGatewayRouteTableRoutes(
 
 	stateFilter := types.Filter{
 		Name:   aws.String("state"),
-		Values: []string{"active", "blackhole"},
+		Values: []string{string(types.TransitGatewayRouteStateActive), string(types.TransitGatewayRouteStateBlackhole)},
 	}
 
 	result, err := searchTGWRoutes(ctx, svc, routeTableId, []types.Filter{stateFilter})
@@ -57,21 +57,24 @@ func GetTransitGatewayRouteTableRoutes(
 	}
 
 	// The single-filter response was truncated. Split by route type to cover
-	// the full result set. The union of "static" and "propagated" equals the
-	// entire set of routes in the table. The initial (truncated) result is
+	// the full result set. The union of static and propagated route types equals
+	// the entire set of routes in the table. The initial (truncated) result is
 	// discarded because the narrowed calls return complete, independent sets.
 	var combined []types.TransitGatewayRoute
-	for _, routeType := range []string{"static", "propagated"} {
+	for _, routeType := range []types.TransitGatewayRouteType{
+		types.TransitGatewayRouteTypeStatic,
+		types.TransitGatewayRouteTypePropagated,
+	} {
 		typeFilter := types.Filter{
 			Name:   aws.String("type"),
-			Values: []string{routeType},
+			Values: []string{string(routeType)},
 		}
 		narrowed, err := searchTGWRoutes(ctx, svc, routeTableId, []types.Filter{stateFilter, typeFilter})
 		if err != nil {
 			return nil, err
 		}
 		if additionalRoutesAvailable(narrowed) {
-			return nil, fmt.Errorf("route table %s type=%s: %w", routeTableId, routeType, ErrTGWRoutesTruncated)
+			return nil, fmt.Errorf("route table %s type=%s: %w", routeTableId, string(routeType), ErrTGWRoutesTruncated)
 		}
 		combined = append(combined, narrowed.Routes...)
 	}

--- a/lib/tgw_routetables.go
+++ b/lib/tgw_routetables.go
@@ -36,8 +36,10 @@ func GetTransitGatewayRouteTableRoutes(
 	routeTableId string,
 	svc EC2SearchTransitGatewayRoutesAPI,
 ) ([]types.TransitGatewayRoute, error) {
-	// Add timeout to context for API call(s)
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	// Add a timeout budget for the API call(s). A single query can take up to
+	// 30s; the narrowing path may issue up to three sequential calls (one
+	// initial, two narrowed by type), so the budget is scaled accordingly.
+	ctx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 
 	stateFilter := types.Filter{
@@ -56,8 +58,9 @@ func GetTransitGatewayRouteTableRoutes(
 
 	// The single-filter response was truncated. Split by route type to cover
 	// the full result set. The union of "static" and "propagated" equals the
-	// entire set of routes in the table.
-	combined := make([]types.TransitGatewayRoute, 0, len(result.Routes))
+	// entire set of routes in the table. The initial (truncated) result is
+	// discarded because the narrowed calls return complete, independent sets.
+	var combined []types.TransitGatewayRoute
 	for _, routeType := range []string{"static", "propagated"} {
 		typeFilter := types.Filter{
 			Name:   aws.String("type"),
@@ -92,7 +95,7 @@ func searchTGWRoutes(
 	result, err := svc.SearchTransitGatewayRoutes(ctx, &input)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("API call timed out after 30 seconds: %w", err)
+			return nil, fmt.Errorf("API call timed out: %w", err)
 		}
 
 		var apiErr smithy.APIError

--- a/lib/tgw_routetables_test.go
+++ b/lib/tgw_routetables_test.go
@@ -294,6 +294,108 @@ func TestGetTransitGatewayRouteTableRoutes(t *testing.T) {
 	}
 }
 
+// TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAvailable is a regression test
+// for T-881. When SearchTransitGatewayRoutes returns AdditionalRoutesAvailable=true with
+// the default (state-only) filter, the function must narrow the query by route type
+// (static and propagated) to retrieve the remaining routes. The two type-filtered calls
+// together cover the full result set.
+func TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAvailable(t *testing.T) {
+	staticRoute := types.TransitGatewayRoute{
+		DestinationCidrBlock: aws.String("10.0.0.0/16"),
+		State:                types.TransitGatewayRouteStateActive,
+		Type:                 types.TransitGatewayRouteTypeStatic,
+		TransitGatewayAttachments: []types.TransitGatewayRouteAttachment{
+			{TransitGatewayAttachmentId: aws.String("tgw-attach-11111111")},
+		},
+	}
+	propagatedRoute := types.TransitGatewayRoute{
+		DestinationCidrBlock: aws.String("10.1.0.0/16"),
+		State:                types.TransitGatewayRouteStateActive,
+		Type:                 types.TransitGatewayRouteTypePropagated,
+		TransitGatewayAttachments: []types.TransitGatewayRouteAttachment{
+			{TransitGatewayAttachmentId: aws.String("tgw-attach-22222222")},
+		},
+	}
+
+	hasTypeFilter := func(params *ec2.SearchTransitGatewayRoutesInput, value string) bool {
+		for _, f := range params.Filters {
+			if f.Name == nil || *f.Name != "type" {
+				continue
+			}
+			for _, v := range f.Values {
+				if v == value {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	callCount := 0
+	svc := mockEC2SearchTransitGatewayRoutesAPI(func(ctx context.Context, params *ec2.SearchTransitGatewayRoutesInput, optFns ...func(*ec2.Options)) (*ec2.SearchTransitGatewayRoutesOutput, error) {
+		callCount++
+		switch {
+		case hasTypeFilter(params, "static"):
+			return &ec2.SearchTransitGatewayRoutesOutput{
+				Routes:                    []types.TransitGatewayRoute{staticRoute},
+				AdditionalRoutesAvailable: aws.Bool(false),
+			}, nil
+		case hasTypeFilter(params, "propagated"):
+			return &ec2.SearchTransitGatewayRoutesOutput{
+				Routes:                    []types.TransitGatewayRoute{propagatedRoute},
+				AdditionalRoutesAvailable: aws.Bool(false),
+			}, nil
+		default:
+			// Initial call with no type filter — signal truncation.
+			return &ec2.SearchTransitGatewayRoutesOutput{
+				Routes:                    []types.TransitGatewayRoute{staticRoute},
+				AdditionalRoutesAvailable: aws.Bool(true),
+			}, nil
+		}
+	})
+
+	got, err := GetTransitGatewayRouteTableRoutes(context.Background(), "tgw-rtb-many", svc)
+	if err != nil {
+		t.Fatalf("GetTransitGatewayRouteTableRoutes() unexpected error: %v", err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 routes after narrowing, got %d (callCount=%d)", len(got), callCount)
+	}
+
+	destinations := map[string]bool{}
+	for _, r := range got {
+		destinations[GetTGWRouteDestination(r)] = true
+	}
+	if !destinations["10.0.0.0/16"] || !destinations["10.1.0.0/16"] {
+		t.Errorf("expected both static and propagated routes, got destinations %v", destinations)
+	}
+}
+
+// TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAfterNarrowing is a regression
+// test for T-881. When even the narrowed-by-type queries still report
+// AdditionalRoutesAvailable=true, the function must return an explicit error rather than
+// silently returning partial route data.
+func TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAfterNarrowing(t *testing.T) {
+	svc := mockEC2SearchTransitGatewayRoutesAPI(func(ctx context.Context, params *ec2.SearchTransitGatewayRoutesInput, optFns ...func(*ec2.Options)) (*ec2.SearchTransitGatewayRoutesOutput, error) {
+		// Every call — initial and narrowed — reports more routes available.
+		return &ec2.SearchTransitGatewayRoutesOutput{
+			Routes: []types.TransitGatewayRoute{
+				{DestinationCidrBlock: aws.String("10.0.0.0/16"), State: types.TransitGatewayRouteStateActive, Type: types.TransitGatewayRouteTypeStatic},
+			},
+			AdditionalRoutesAvailable: aws.Bool(true),
+		}, nil
+	})
+
+	_, err := GetTransitGatewayRouteTableRoutes(context.Background(), "tgw-rtb-overflow", svc)
+	if err == nil {
+		t.Fatal("expected an error when AdditionalRoutesAvailable remains true after narrowing, got nil")
+	}
+	if !errors.Is(err, ErrTGWRoutesTruncated) {
+		t.Errorf("expected error to wrap ErrTGWRoutesTruncated, got %v", err)
+	}
+}
+
 // TestExtractStringProperty_NilParameterKeyAndValue verifies that extractStringProperty
 // does not panic when parameter entries have nil ParameterKey or ParameterValue fields.
 func TestExtractStringProperty_NilParameterKeyAndValue(t *testing.T) {

--- a/lib/tgw_routetables_test.go
+++ b/lib/tgw_routetables_test.go
@@ -359,6 +359,13 @@ func TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAvailable(t *testing.
 		t.Fatalf("GetTransitGatewayRouteTableRoutes() unexpected error: %v", err)
 	}
 
+	// Lock in the expected call sequence: 1 initial + 2 narrowed (static,
+	// propagated). Guards against future changes that silently alter the
+	// fallback strategy.
+	if callCount != 3 {
+		t.Errorf("expected 3 API calls (1 initial + 2 narrowed), got %d", callCount)
+	}
+
 	if len(got) != 2 {
 		t.Fatalf("expected 2 routes after narrowing, got %d (callCount=%d)", len(got), callCount)
 	}
@@ -369,6 +376,42 @@ func TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAvailable(t *testing.
 	}
 	if !destinations["10.0.0.0/16"] || !destinations["10.1.0.0/16"] {
 		t.Errorf("expected both static and propagated routes, got destinations %v", destinations)
+	}
+}
+
+// TestGetTransitGatewayRouteTableRoutes_NarrowedCallError is a regression test
+// for T-881. When a narrowed-by-type retry fails with an API error (for
+// example UnauthorizedOperation on a subset of routes), the error must be
+// propagated to the caller rather than swallowed.
+func TestGetTransitGatewayRouteTableRoutes_NarrowedCallError(t *testing.T) {
+	staticRoute := types.TransitGatewayRoute{
+		DestinationCidrBlock: aws.String("10.0.0.0/16"),
+		State:                types.TransitGatewayRouteStateActive,
+		Type:                 types.TransitGatewayRouteTypeStatic,
+	}
+
+	svc := mockEC2SearchTransitGatewayRoutesAPI(func(ctx context.Context, params *ec2.SearchTransitGatewayRoutesInput, optFns ...func(*ec2.Options)) (*ec2.SearchTransitGatewayRoutesOutput, error) {
+		hasType := false
+		for _, f := range params.Filters {
+			if f.Name != nil && *f.Name == "type" {
+				hasType = true
+				break
+			}
+		}
+		if !hasType {
+			// Initial call signals truncation to trigger the narrowing path.
+			return &ec2.SearchTransitGatewayRoutesOutput{
+				Routes:                    []types.TransitGatewayRoute{staticRoute},
+				AdditionalRoutesAvailable: aws.Bool(true),
+			}, nil
+		}
+		// Any narrowed call fails with an API error.
+		return nil, &smithy.GenericAPIError{Code: "UnauthorizedOperation", Message: "insufficient permissions"}
+	})
+
+	_, err := GetTransitGatewayRouteTableRoutes(context.Background(), "tgw-rtb-narrowerr", svc)
+	if err == nil {
+		t.Fatal("expected error from narrowed call to be propagated, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fixes T-881: `lib.GetTransitGatewayRouteTableRoutes` called `SearchTransitGatewayRoutes` once and returned `result.Routes` without checking `AdditionalRoutesAvailable`. EC2 caps responses at 1000 routes and does not expose a `NextToken`, so larger TGW route tables had later routes silently dropped from drift detection.
- When the initial state-filtered call is truncated, retry with a `type` filter (static and propagated) and return the union. The two type-filtered calls partition the full result set.
- If either narrowed call still reports additional routes, return an error wrapping the new `ErrTGWRoutesTruncated` sentinel so callers see the truncation instead of partial data.

## Root Cause

`SearchTransitGatewayRoutes` does not paginate via `NextToken`; it uses `AdditionalRoutesAvailable` to flag truncation. The previous implementation ignored the flag, leaving drift detection to silently miss routes on route tables with more than 1000 active/blackhole entries.

## Test plan

- [x] New regression tests in `lib/tgw_routetables_test.go`:
  - `TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAvailable` — narrowing retrieves the full static + propagated union when the initial call is truncated.
  - `TestGetTransitGatewayRouteTableRoutes_AdditionalRoutesAfterNarrowing` — returns `ErrTGWRoutesTruncated` when narrowing is still insufficient.
- [x] `go test ./...`
- [x] `INTEGRATION=1 go test ./...`
- [x] `golangci-lint run ./lib/...`
- [x] `go vet ./...`