### PR TITLE
Fix T-846: Enforce golangci-lint v2 for make lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Before opening a pull request run the following commands:
 
 1. `gofmt`
 2. `go test ./... -v`
-3. `golangci-lint run`
+3. `golangci-lint run` (requires golangci-lint v2 — install with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`; `make lint` runs a preflight that enforces this)
 4. Optionally `go build -o fog` to confirm the project builds.
 
 ## Code Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,9 @@ INTEGRATION=1 go test ./... -cover
 - `./fog [command]` - Run the compiled binary
 
 ### Linting
-- The project uses `golangci-lint` in CI/CD
-- Install locally with: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
-- Run with: `golangci-lint run`
+- The project uses `golangci-lint` v2 in CI/CD (the repo's `.golangci.yml` uses the v2 schema)
+- Install locally with: `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`
+- Run with: `golangci-lint run` (or `make lint`, which runs a version preflight via `scripts/check-golangci-lint.sh`)
 
 ## Architecture Overview
 

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,9 @@ fmt:
 vet:
 	go vet ./...
 
-# Run linter (requires golangci-lint)
+# Run linter (requires golangci-lint v2; .golangci.yml uses the v2 schema)
 lint:
+	@./scripts/check-golangci-lint.sh
 	golangci-lint run
 
 # Run modernize to update code to modern Go patterns (requires modernize)

--- a/README.md
+++ b/README.md
@@ -448,9 +448,21 @@ INTEGRATION=1 go test ./...
 
 #### Linting
 
+The project's `.golangci.yml` uses the golangci-lint v2 schema. Install v2
+(the v2 module path — the plain `cmd/golangci-lint@latest` installs v1) with:
+
 ```bash
-# Run golangci-lint
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+```
+
+Then run:
+
+```bash
+# Run golangci-lint (make lint also runs a version preflight)
 golangci-lint run
+
+# Or via the Makefile, which validates the installed version first
+make lint
 
 # Format code
 go fmt ./...

--- a/docs/agent-notes/linting.md
+++ b/docs/agent-notes/linting.md
@@ -1,0 +1,30 @@
+# Linting
+
+## Toolchain
+
+- `.golangci.yml` uses the golangci-lint v2 schema (`version: "2"`). A v1
+  binary cannot read it and will exit with "config v2 / binary v1".
+- Install v2 explicitly (the plain `cmd/golangci-lint@latest` resolves to v1):
+  `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`
+- CI (`.github/workflows/push.yml`) uses `golangci/golangci-lint-action@v8`
+  with `version: latest`, so CI always runs the current v2.
+
+## Preflight
+
+- `make lint` and `test/validate_tests.sh` both invoke
+  `scripts/check-golangci-lint.sh` before running `golangci-lint run`. The
+  script fails fast with an install command when the binary is missing or not
+  v2.
+- Regression coverage for the preflight lives in
+  `test/lint/check_golangci_lint_version_test.sh`. It stubs `golangci-lint` on
+  PATH with fake v1/v2/missing binaries and exercises the exit codes and
+  messages.
+
+## Gotchas
+
+- `golangci-lint --version` formats differ between majors:
+  - v1: `golangci-lint has version v1.64.8 built ...`
+  - v2: `golangci-lint has version 2.1.6 built ...` (no leading `v`)
+  The preflight parser tolerates both (optional leading `v`).
+- When bumping the config schema, update `scripts/check-golangci-lint.sh`
+  (`REQUIRED_MAJOR`) alongside.

--- a/scripts/check-golangci-lint.sh
+++ b/scripts/check-golangci-lint.sh
@@ -6,7 +6,7 @@
 # fast with an actionable message otherwise, so contributors don't have to
 # interpret the raw "config v2 / binary v1" error from the linter itself.
 
-set -u
+set -eu
 
 REQUIRED_MAJOR=2
 INSTALL_CMD='go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest'
@@ -16,7 +16,7 @@ if ! command -v golangci-lint >/dev/null 2>&1; then
 error: golangci-lint is not installed or not on PATH.
 
 This repository requires golangci-lint v${REQUIRED_MAJOR} (its .golangci.yml
-uses the v2 schema). Install it with:
+uses the v${REQUIRED_MAJOR} schema). Install it with:
 
     ${INSTALL_CMD}
 EOF

--- a/scripts/check-golangci-lint.sh
+++ b/scripts/check-golangci-lint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Preflight check used by `make lint` and test/validate_tests.sh.
+#
+# The project's .golangci.yml declares `version: "2"`, which is only understood
+# by golangci-lint v2. This script verifies a v2 binary is on PATH and fails
+# fast with an actionable message otherwise, so contributors don't have to
+# interpret the raw "config v2 / binary v1" error from the linter itself.
+
+set -u
+
+REQUIRED_MAJOR=2
+INSTALL_CMD='go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest'
+
+if ! command -v golangci-lint >/dev/null 2>&1; then
+    cat >&2 <<EOF
+error: golangci-lint is not installed or not on PATH.
+
+This repository requires golangci-lint v${REQUIRED_MAJOR} (its .golangci.yml
+uses the v2 schema). Install it with:
+
+    ${INSTALL_CMD}
+EOF
+    exit 1
+fi
+
+# `golangci-lint --version` output lines we need to handle:
+#   v1: "golangci-lint has version v1.64.8 built with go1.22.0 from ..."
+#   v2: "golangci-lint has version 2.1.6 built with go1.22.0 from ..."
+VERSION_OUTPUT="$(golangci-lint --version 2>&1 | head -n1)"
+
+# Extract the first X.Y(.Z) token; tolerate an optional leading 'v'.
+VERSION="$(printf '%s\n' "$VERSION_OUTPUT" | sed -E 's/.*version v?([0-9]+\.[0-9]+(\.[0-9]+)?).*/\1/')"
+if [ -z "$VERSION" ] || [ "$VERSION" = "$VERSION_OUTPUT" ]; then
+    cat >&2 <<EOF
+error: could not determine golangci-lint version from:
+    ${VERSION_OUTPUT}
+
+This repository requires golangci-lint v${REQUIRED_MAJOR}. Install it with:
+
+    ${INSTALL_CMD}
+EOF
+    exit 1
+fi
+
+MAJOR="${VERSION%%.*}"
+if [ "$MAJOR" != "$REQUIRED_MAJOR" ]; then
+    cat >&2 <<EOF
+error: golangci-lint v${MAJOR} detected (${VERSION}), but this repository's
+.golangci.yml uses the v${REQUIRED_MAJOR} schema. Install v${REQUIRED_MAJOR}
+with:
+
+    ${INSTALL_CMD}
+EOF
+    exit 1
+fi
+
+exit 0

--- a/specs/bugfixes/golangci-lint-v2-config/report.md
+++ b/specs/bugfixes/golangci-lint-v2-config/report.md
@@ -1,0 +1,150 @@
+# Bugfix Report: golangci-lint-v2-config
+
+**Date:** 2026-04-20
+**Status:** Fixed
+**Ticket:** T-846
+
+## Description of the Issue
+
+`make lint` runs `golangci-lint run` without validating the installed binary.
+The repository's `.golangci.yml` declares `version: "2"`, which is only
+understood by golangci-lint v2. When a developer has v1 installed (for example
+v1.64.8, the final v1 release), the linter aborts immediately with:
+
+```
+Error: you are using a configuration file for golangci-lint v2 with golangci-lint v1: please use golangci-lint v2
+make: *** [lint] Error 3
+```
+
+The error is clear in isolation, but the Makefile/README/AGENTS flow gives no
+hint that v2 is required. Because `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
+installs the v1 line (the v2 module lives at `.../v2/cmd/golangci-lint`), anyone
+following the documented install command ends up with a broken local lint
+target while CI still passes (the GitHub action pins `version: latest` which
+resolves to v2).
+
+**Reproduction steps:**
+
+1. Install the documented v1 path: `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`
+2. From the repo root run `make lint`
+3. Observe the failure: the v1 binary rejects the v2 config
+
+**Impact:** Local validation is broken for any contributor who follows the
+current install instructions, and the failure mode is ambiguous — developers
+may think the project itself is misconfigured rather than their toolchain.
+
+## Investigation Summary
+
+- **Symptoms examined:** `make lint` exits with "you are using a configuration file for golangci-lint v2 with golangci-lint v1" when the local binary is v1.64.8.
+- **Code inspected:** `Makefile` (`lint` target), `.golangci.yml` (version pin), `test/validate_tests.sh` (step 6 also invokes `golangci-lint run`), `.github/workflows/push.yml` (CI uses `version: latest` in `golangci/golangci-lint-action@v8`), `README.md`, `AGENTS.md`, `CLAUDE.md` (install instructions).
+- **Hypotheses tested:**
+  - "Downgrade the config to v1" — rejected, v2 is the supported line and carries forward-looking features.
+  - "Add a `.tool-versions` pin" — possible, but still relies on the user having mise/asdf and wouldn't produce a clear error from `make lint` alone.
+  - "Check the binary version inside `make lint`" — chosen, because it fails fast with a direct message wherever the Makefile target runs.
+
+## Discovered Root Cause
+
+`make lint` (and `test/validate_tests.sh`) assume the installed `golangci-lint`
+matches the v2 schema of `.golangci.yml`, but nothing enforces that
+assumption. The documented install command (`go install .../cmd/golangci-lint@latest`)
+resolves to v1 because v2 moved to a separate module path (`.../v2/cmd/golangci-lint`).
+Combined, these produce an ambiguous error from the linter binary itself rather
+than a build-system-level diagnostic that points at the real cause (wrong major
+version installed).
+
+**Defect type:** Missing preflight check + stale install documentation.
+
+**Why it occurred:** The `.golangci.yml` was upgraded to `version: "2"` after
+golangci-lint released v2, but the Makefile target, helper script, and
+developer-facing install instructions were not updated to match.
+
+**Contributing factors:** CI uses `version: latest`, so breakage is invisible
+in CI and only surfaces locally.
+
+## Resolution for the Issue
+
+**Changes made:**
+
+- `scripts/check-golangci-lint.sh` — new preflight script. Looks up
+  `golangci-lint` on PATH, parses `--version`, and fails with a clear message
+  ("requires golangci-lint v2; found vX...; install with `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`") when the major version is not 2 or the binary is missing.
+- `Makefile` (`lint` target) — invokes the preflight script before
+  `golangci-lint run` so misconfigured environments fail with a targeted
+  diagnostic instead of the raw linter error.
+- `test/validate_tests.sh` — same preflight invocation in step 6.
+- `README.md`, `CLAUDE.md`, `AGENTS.md` — update install command to the v2
+  module path (`github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`)
+  and note that v2 is required.
+- `test/lint/check_golangci_lint_version_test.sh` — regression test that stubs
+  `golangci-lint` with v1/v2/missing binaries and verifies the preflight's
+  exit codes and messaging.
+
+**Approach rationale:** A Makefile preflight centralises the version contract
+in one place, produces a targeted error, and doesn't require contributors to
+adopt a new tool manager. Updating the docs at the same time removes the
+install command that silently lands on v1.
+
+**Alternatives considered:**
+
+- **Pin via `.tool-versions` / `mise.toml`** — rejected as the sole fix: users
+  without mise/asdf would still hit the raw linter error. The preflight works
+  regardless of tool manager; a `.tool-versions` file could be added later as
+  an additive convenience.
+- **Downgrade the config to v1** — rejected because v2 is the supported line
+  and CI already runs v2.
+- **Inline the check in the Makefile recipe** — rejected in favour of a
+  dedicated script so `test/validate_tests.sh` can reuse the same logic and so
+  the check is testable with stub PATHs.
+
+## Regression Test
+
+**Test file:** `test/lint/check_golangci_lint_version_test.sh`
+
+**What it verifies:**
+
+- v1 binary on PATH causes the preflight to exit non-zero and the message
+  mentions the v2 requirement.
+- v2 binary on PATH causes the preflight to succeed (exit 0).
+- Missing binary causes the preflight to exit non-zero with an install hint.
+
+**Run command:** `./test/lint/check_golangci_lint_version_test.sh`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `scripts/check-golangci-lint.sh` | New preflight script that enforces v2 and produces actionable error messages |
+| `Makefile` | `lint` target now runs the preflight before `golangci-lint run` |
+| `test/validate_tests.sh` | Step 6 now runs the preflight before invoking the linter |
+| `README.md` | Updated install instructions to the v2 module path and documented the v2 requirement |
+| `CLAUDE.md` | Same update for project guidance |
+| `AGENTS.md` | Same update for contributor guidance |
+| `test/lint/check_golangci_lint_version_test.sh` | New regression test for T-846 |
+
+## Verification
+
+**Automated:**
+
+- [x] Regression test passes (`./test/lint/check_golangci_lint_version_test.sh`)
+- [x] Full test suite passes (`go test ./...`)
+- [x] `make lint` with a v2 binary succeeds; with v1 it fails with the new targeted message
+
+**Manual verification:**
+
+- Ran `make lint` with the local v1.64.8 binary: produced the new preflight
+  diagnostic instead of the raw v2-config error.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+
+- When bumping config schema versions for tools invoked from the Makefile, add
+  or update the preflight checks alongside the config change.
+- Keep install commands in docs aligned with the module path actually required
+  — for golangci-lint specifically, v2 lives at `.../v2/cmd/golangci-lint`.
+- Consider adding a `.tool-versions` file as a future improvement so mise/asdf
+  users get the right binary automatically.
+
+## Related
+
+- T-846: `make lint` fails with unpinned golangci-lint v2 config

--- a/test/lint/check_golangci_lint_version_test.sh
+++ b/test/lint/check_golangci_lint_version_test.sh
@@ -4,8 +4,7 @@
 # `version: "2"`, so a v1 binary cannot lint the project).
 #
 # The test stubs `golangci-lint` on PATH with fake binaries reporting different
-# versions and invokes the shared preflight script (scripts/check-golangci-lint.sh)
-# plus the `make lint` target.
+# versions and invokes the shared preflight script (scripts/check-golangci-lint.sh).
 #
 # Expected behaviour after the fix:
 #   - v1 binary  -> preflight exits non-zero with a message mentioning "v2"
@@ -19,8 +18,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 CHECK_SCRIPT="$REPO_ROOT/scripts/check-golangci-lint.sh"
 
 FAIL=0
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+TEST_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
 assert() {
     local description="$1"
@@ -80,7 +79,7 @@ if [ ! -x "$CHECK_SCRIPT" ]; then
 fi
 
 # Case 1: v1 binary on PATH -> must fail with a v2 requirement message.
-V1_DIR="$TMPDIR/v1"
+V1_DIR="$TEST_TMPDIR/v1"
 make_fake_binary "$V1_DIR" "golangci-lint has version v1.64.8 built with go1.22.0 from unknown"
 set +e
 OUT_V1="$(PATH="$V1_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" 2>&1)"
@@ -90,7 +89,7 @@ assert "v1 binary causes preflight to fail" "1" "$([ $RC_V1 -ne 0 ] && echo 1 ||
 assert_contains "v1 failure mentions v2 requirement" "v2" "$OUT_V1"
 
 # Case 2: v2 binary on PATH -> preflight succeeds.
-V2_DIR="$TMPDIR/v2"
+V2_DIR="$TEST_TMPDIR/v2"
 make_fake_binary "$V2_DIR" "golangci-lint has version 2.1.6 built with go1.22.0 from abc123"
 set +e
 OUT_V2="$(PATH="$V2_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" 2>&1)"
@@ -99,7 +98,7 @@ set -e
 assert "v2 binary is accepted" "0" "$RC_V2"
 
 # Case 3: no binary on PATH -> fail with install hint.
-EMPTY_DIR="$TMPDIR/empty"
+EMPTY_DIR="$TEST_TMPDIR/empty"
 mkdir -p "$EMPTY_DIR"
 set +e
 OUT_MISSING="$(PATH="$EMPTY_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" 2>&1)"

--- a/test/lint/check_golangci_lint_version_test.sh
+++ b/test/lint/check_golangci_lint_version_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Regression test for T-846: make lint should fail with a clear v2 requirement
+# message when the installed golangci-lint is a v1 binary (the repo config uses
+# `version: "2"`, so a v1 binary cannot lint the project).
+#
+# The test stubs `golangci-lint` on PATH with fake binaries reporting different
+# versions and invokes the shared preflight script (scripts/check-golangci-lint.sh)
+# plus the `make lint` target.
+#
+# Expected behaviour after the fix:
+#   - v1 binary  -> preflight exits non-zero with a message mentioning "v2"
+#   - v2 binary  -> preflight exits zero (invocation succeeds, linter runs)
+#   - missing    -> preflight exits non-zero with an install hint
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CHECK_SCRIPT="$REPO_ROOT/scripts/check-golangci-lint.sh"
+
+FAIL=0
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        echo "  PASS: $description"
+    else
+        echo "  FAIL: $description"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAIL=1
+    fi
+}
+
+assert_contains() {
+    local description="$1"
+    local needle="$2"
+    local haystack="$3"
+    case "$haystack" in
+        *"$needle"*) echo "  PASS: $description" ;;
+        *)
+            echo "  FAIL: $description"
+            echo "    expected to contain: $needle"
+            echo "    actual output: $haystack"
+            FAIL=1
+            ;;
+    esac
+}
+
+make_fake_binary() {
+    local dir="$1"
+    local version_output="$2"
+    mkdir -p "$dir"
+    cat > "$dir/golangci-lint" <<EOF
+#!/usr/bin/env bash
+case "\$1" in
+    --version|version)
+        printf '%s\n' "$version_output"
+        exit 0
+        ;;
+    *)
+        # Pretend run succeeds so we can see the preflight decides.
+        exit 0
+        ;;
+esac
+EOF
+    chmod +x "$dir/golangci-lint"
+}
+
+echo "T-846 regression: golangci-lint version preflight"
+echo "=================================================="
+
+if [ ! -x "$CHECK_SCRIPT" ]; then
+    echo "  FAIL: preflight script missing or not executable: $CHECK_SCRIPT"
+    exit 1
+fi
+
+# Case 1: v1 binary on PATH -> must fail with a v2 requirement message.
+V1_DIR="$TMPDIR/v1"
+make_fake_binary "$V1_DIR" "golangci-lint has version v1.64.8 built with go1.22.0 from unknown"
+set +e
+OUT_V1="$(PATH="$V1_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" 2>&1)"
+RC_V1=$?
+set -e
+assert "v1 binary causes preflight to fail" "1" "$([ $RC_V1 -ne 0 ] && echo 1 || echo 0)"
+assert_contains "v1 failure mentions v2 requirement" "v2" "$OUT_V1"
+
+# Case 2: v2 binary on PATH -> preflight succeeds.
+V2_DIR="$TMPDIR/v2"
+make_fake_binary "$V2_DIR" "golangci-lint has version 2.1.6 built with go1.22.0 from abc123"
+set +e
+OUT_V2="$(PATH="$V2_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" 2>&1)"
+RC_V2=$?
+set -e
+assert "v2 binary is accepted" "0" "$RC_V2"
+
+# Case 3: no binary on PATH -> fail with install hint.
+EMPTY_DIR="$TMPDIR/empty"
+mkdir -p "$EMPTY_DIR"
+set +e
+OUT_MISSING="$(PATH="$EMPTY_DIR:/usr/bin:/bin" "$CHECK_SCRIPT" 2>&1)"
+RC_MISSING=$?
+set -e
+assert "missing binary causes preflight to fail" "1" "$([ $RC_MISSING -ne 0 ] && echo 1 || echo 0)"
+assert_contains "missing binary output mentions install hint" "install" "$OUT_MISSING"
+
+if [ $FAIL -ne 0 ]; then
+    echo "FAIL"
+    exit 1
+fi
+
+echo "OK"

--- a/test/validate_tests.sh
+++ b/test/validate_tests.sh
@@ -69,9 +69,12 @@ echo "Detailed per-package coverage:"
 go tool cover -func=coverage.out | grep -E "^(github.com|total:)" | grep -v "total:"
 echo
 
-# 6. Run golangci-lint if available
+# 6. Run golangci-lint if available (requires v2 — see scripts/check-golangci-lint.sh)
 echo "Step 6: Running golangci-lint..."
 if command -v golangci-lint &> /dev/null; then
+    if ! ./scripts/check-golangci-lint.sh; then
+        exit 1
+    fi
     golangci-lint run
     LINT_EXIT=$?
     print_status $LINT_EXIT "Linting"

--- a/test/validate_tests.sh
+++ b/test/validate_tests.sh
@@ -4,6 +4,9 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -72,7 +75,7 @@ echo
 # 6. Run golangci-lint if available (requires v2 — see scripts/check-golangci-lint.sh)
 echo "Step 6: Running golangci-lint..."
 if command -v golangci-lint &> /dev/null; then
-    if ! ./scripts/check-golangci-lint.sh; then
+    if ! "$REPO_ROOT/scripts/check-golangci-lint.sh"; then
         exit 1
     fi
     golangci-lint run


### PR DESCRIPTION
## Summary

- `make lint` previously delegated straight to `golangci-lint run`. The repo's `.golangci.yml` uses `version: "2"`, so any contributor with a v1 binary installed (e.g. via the documented `go install .../cmd/golangci-lint@latest`, which resolves to v1) saw the ambiguous "config v2 / binary v1" error with no hint that the toolchain was at fault.
- Adds a shared preflight script (`scripts/check-golangci-lint.sh`) that validates the installed `golangci-lint` is v2 and prints an actionable install command when it isn't (or when the binary is missing). Both `make lint` and `test/validate_tests.sh` invoke it before running the linter.
- Updates install instructions in `README.md`, `CLAUDE.md`, and `AGENTS.md` to the v2 module path (`github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`) so the documented flow lands on a v2 binary by default. Adds `docs/agent-notes/linting.md` recording the lint toolchain contract.
- Ships a shell regression test (`test/lint/check_golangci_lint_version_test.sh`) that stubs `golangci-lint` on PATH with fake v1/v2/missing binaries and asserts the preflight's exit codes and messages.

Full report: [`specs/bugfixes/golangci-lint-v2-config/report.md`](specs/bugfixes/golangci-lint-v2-config/report.md).

## Test plan

- [x] `./test/lint/check_golangci_lint_version_test.sh` passes (all three stubbed PATH cases)
- [x] `go test ./...` passes
- [x] `make lint` with a v2 binary succeeds (`0 issues.`)
- [x] `make lint` with a simulated v1 binary on PATH fails fast with the new diagnostic and install command