### PR TITLE
Fix T-865: Honor --deploy-changeset flag in deploy command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -98,21 +98,27 @@ func deployTemplate(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	changeset := createAndShowChangeset(&deployment, awsConfig, &deploymentLog, deployFlags.Quiet)
+	var changeset *lib.ChangesetInfo
+	if deployFlags.DeployChangeset {
+		// Deploy an existing, previously-created changeset by name.
+		changeset = runDeployChangesetFlow(&deployment, awsConfig, &deploymentLog, deployFlags.Quiet)
+	} else {
+		changeset = createAndShowChangeset(&deployment, awsConfig, &deploymentLog, deployFlags.Quiet)
 
-	// Handle dry-run mode
-	if deployment.IsDryRun {
-		outputDryRunResult(&deployment, awsConfig)
-		// Delete changeset after output for dry-run
-		deleteChangeset(deployment, awsConfig)
-		return
-	}
+		// Handle dry-run mode
+		if deployment.IsDryRun {
+			outputDryRunResult(&deployment, awsConfig)
+			// Delete changeset after output for dry-run
+			deleteChangeset(deployment, awsConfig)
+			return
+		}
 
-	// Handle create-changeset mode
-	if deployFlags.CreateChangeset {
-		outputDryRunResult(&deployment, awsConfig)
-		// Do NOT delete changeset for --create-changeset mode
-		return
+		// Handle create-changeset mode
+		if deployFlags.CreateChangeset {
+			outputDryRunResult(&deployment, awsConfig)
+			// Do NOT delete changeset for --create-changeset mode
+			return
+		}
 	}
 
 	deployed, err := confirmAndDeployChangeset(changeset, &deployment, awsConfig)
@@ -340,6 +346,26 @@ func loadParametersFromFiles(parameterFiles string) []types.Parameter {
 		parameters = append(parameters, parsedparameters...)
 	}
 	return parameters
+}
+
+// fetchChangeset retrieves an existing changeset (named by --changeset) and
+// attaches it to the deployment so it can be executed without creating a new
+// one. Used by the --deploy-changeset flow.
+func fetchChangeset(deployment *lib.DeployInfo, awsConfig config.AWSConfig) *lib.ChangesetInfo {
+	ctx := context.Background()
+	rawchangeset, err := deployment.GetChangeset(ctx, awsConfig.CloudformationClient())
+	if err != nil {
+		message := fmt.Sprintf(string(texts.DeployChangesetMessageRetrieveFailed), deployment.ChangesetName)
+		printMessage(formatError(message))
+		log.Fatalln(err)
+	}
+	if len(rawchangeset) == 0 {
+		message := fmt.Sprintf(string(texts.DeployChangesetMessageRetrieveFailed), deployment.ChangesetName)
+		printMessage(formatError(message))
+		os.Exit(1)
+	}
+	changeset := deployment.AddChangeset(rawchangeset)
+	return &changeset
 }
 
 func createChangeset(deployment *lib.DeployInfo, awsConfig config.AWSConfig) *lib.ChangesetInfo {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -86,16 +86,22 @@ func deployTemplate(cmd *cobra.Command, args []string) {
 
 	deploymentLog := lib.NewDeploymentLog(awsConfig, deployment)
 
-	precheckOutput, abort := runPrechecks(&deployment, &deploymentLog)
-	if precheckOutput != "" {
-		printMessage(precheckOutput)
-	}
-	if abort {
-		if err := deploymentLog.Failed(nil); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to write deployment log: %v\n", err)
+	// Prechecks rely on the local template path ($TEMPLATEPATH substitution).
+	// In --deploy-changeset mode no template is loaded, so skip prechecks to
+	// avoid running them with an empty path which would produce unreliable
+	// results.
+	if !deployFlags.DeployChangeset {
+		precheckOutput, abort := runPrechecks(&deployment, &deploymentLog)
+		if precheckOutput != "" {
+			printMessage(precheckOutput)
 		}
-		osExitFunc(1)
-		return
+		if abort {
+			if err := deploymentLog.Failed(nil); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: Failed to write deployment log: %v\n", err)
+			}
+			osExitFunc(1)
+			return
+		}
 	}
 
 	var changeset *lib.ChangesetInfo
@@ -350,19 +356,24 @@ func loadParametersFromFiles(parameterFiles string) []types.Parameter {
 
 // fetchChangeset retrieves an existing changeset (named by --changeset) and
 // attaches it to the deployment so it can be executed without creating a new
-// one. Used by the --deploy-changeset flow.
+// one. Used by the --deploy-changeset flow. Errors are reported via
+// printMessage and exit through osExitFunc so tests can intercept them; nil is
+// returned on failure so callers can bail out cleanly in tests.
 func fetchChangeset(deployment *lib.DeployInfo, awsConfig config.AWSConfig) *lib.ChangesetInfo {
 	ctx := context.Background()
 	rawchangeset, err := deployment.GetChangeset(ctx, awsConfig.CloudformationClient())
 	if err != nil {
 		message := fmt.Sprintf(string(texts.DeployChangesetMessageRetrieveFailed), deployment.ChangesetName)
 		printMessage(formatError(message))
-		log.Fatalln(err)
+		printMessage(formatError(err.Error()))
+		osExitFunc(1)
+		return nil
 	}
 	if len(rawchangeset) == 0 {
-		message := fmt.Sprintf(string(texts.DeployChangesetMessageRetrieveFailed), deployment.ChangesetName)
+		message := fmt.Sprintf(string(texts.DeployChangesetMessageNotFound), deployment.ChangesetName)
 		printMessage(formatError(message))
-		os.Exit(1)
+		osExitFunc(1)
+		return nil
 	}
 	changeset := deployment.AddChangeset(rawchangeset)
 	return &changeset

--- a/cmd/deploy_changeset_flag_test.go
+++ b/cmd/deploy_changeset_flag_test.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ArjenSchwarz/fog/config"
+	"github.com/ArjenSchwarz/fog/lib"
+	output "github.com/ArjenSchwarz/go-output/v2"
+)
+
+// TestDeployFlags_Validate_DeployChangeset is a regression test for T-865.
+// The --deploy-changeset flag is supposed to deploy a specific existing
+// changeset. It therefore requires --changeset to identify it and is mutually
+// exclusive with flags that describe creation of a new changeset
+// (--dry-run, --create-changeset, --template, --parameters, --tags,
+// --deployment-file).
+func TestDeployFlags_Validate_DeployChangeset(t *testing.T) {
+	tests := map[string]struct {
+		flags   DeployFlags
+		wantErr bool
+		errMsg  string
+	}{
+		"deploy-changeset with changeset name is valid": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				ChangesetName:   "my-changeset",
+				DeployChangeset: true,
+			},
+			wantErr: false,
+		},
+		"deploy-changeset without changeset name fails": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				DeployChangeset: true,
+			},
+			wantErr: true,
+			errMsg:  "--deploy-changeset requires --changeset",
+		},
+		"deploy-changeset with dry-run fails": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				ChangesetName:   "my-changeset",
+				DeployChangeset: true,
+				Dryrun:          true,
+			},
+			wantErr: true,
+			errMsg:  "cannot be combined",
+		},
+		"deploy-changeset with create-changeset fails": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				ChangesetName:   "my-changeset",
+				DeployChangeset: true,
+				CreateChangeset: true,
+			},
+			wantErr: true,
+			errMsg:  "cannot be combined",
+		},
+		"deploy-changeset with template fails": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				ChangesetName:   "my-changeset",
+				DeployChangeset: true,
+				Template:        "my-template",
+			},
+			wantErr: true,
+			errMsg:  "cannot be combined",
+		},
+		"deploy-changeset with parameters fails": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				ChangesetName:   "my-changeset",
+				DeployChangeset: true,
+				Parameters:      "params.json",
+			},
+			wantErr: true,
+			errMsg:  "cannot be combined",
+		},
+		"deploy-changeset with tags fails": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				ChangesetName:   "my-changeset",
+				DeployChangeset: true,
+				Tags:            "tags.json",
+			},
+			wantErr: true,
+			errMsg:  "cannot be combined",
+		},
+		"deploy-changeset with deployment-file fails": {
+			flags: DeployFlags{
+				StackName:       "my-stack",
+				ChangesetName:   "my-changeset",
+				DeployChangeset: true,
+				DeploymentFile:  "deploy.yaml",
+			},
+			wantErr: true,
+			errMsg:  "cannot be combined",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := tc.flags.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				if tc.errMsg != "" && !strings.Contains(err.Error(), tc.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tc.errMsg, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestDeployTemplate_DeployChangeset_SkipsCreation is a regression test for
+// T-865. When --deploy-changeset is set, deployTemplate must NOT call
+// createChangesetFunc (which creates a new changeset) and must instead
+// retrieve and execute the existing changeset named by --changeset.
+func TestDeployTemplate_DeployChangeset_SkipsCreation(t *testing.T) {
+	createCalled := false
+	fetchCalled := false
+	deployCalled := false
+	showCalled := false
+
+	origCreate := createChangesetFunc
+	origFetch := fetchChangesetFunc
+	origShow := showChangesetFunc
+	origDeploy := deployChangesetFunc
+	origAsk := askForConfirmationFunc
+	origFlags := deployFlags
+	defer func() {
+		createChangesetFunc = origCreate
+		fetchChangesetFunc = origFetch
+		showChangesetFunc = origShow
+		deployChangesetFunc = origDeploy
+		askForConfirmationFunc = origAsk
+		deployFlags = origFlags
+	}()
+
+	createChangesetFunc = func(info *lib.DeployInfo, cfg config.AWSConfig) *lib.ChangesetInfo {
+		createCalled = true
+		return &lib.ChangesetInfo{Name: "new-changeset"}
+	}
+	fetchChangesetFunc = func(info *lib.DeployInfo, cfg config.AWSConfig) *lib.ChangesetInfo {
+		fetchCalled = true
+		return &lib.ChangesetInfo{Name: "existing-changeset"}
+	}
+	showChangesetFunc = func(cs lib.ChangesetInfo, info lib.DeployInfo, cfg config.AWSConfig, optionalBuilder ...*output.Builder) {
+		showCalled = true
+	}
+	deployChangesetFunc = func(info lib.DeployInfo, cfg config.AWSConfig) error {
+		deployCalled = true
+		return nil
+	}
+	askForConfirmationFunc = func(string) bool { return true }
+
+	deployFlags = DeployFlags{
+		StackName:       "my-stack",
+		ChangesetName:   "existing-changeset",
+		DeployChangeset: true,
+	}
+
+	info := lib.DeployInfo{
+		StackName:     "my-stack",
+		ChangesetName: "existing-changeset",
+	}
+	logObj := lib.DeploymentLog{}
+
+	changeset := runDeployChangesetFlow(&info, config.AWSConfig{}, &logObj, false)
+
+	if createCalled {
+		t.Error("createChangesetFunc must not be called when --deploy-changeset is set")
+	}
+	if !fetchCalled {
+		t.Error("fetchChangesetFunc must be called when --deploy-changeset is set")
+	}
+	if !showCalled {
+		t.Error("existing changeset must be displayed before deployment")
+	}
+	if changeset == nil || changeset.Name != "existing-changeset" {
+		t.Errorf("expected existing-changeset, got %+v", changeset)
+	}
+	if info.Changeset == nil || info.Changeset.Name != "existing-changeset" {
+		t.Errorf("expected deployment.Changeset to be populated with existing changeset, got %+v", info.Changeset)
+	}
+	if info.CapturedChangeset == nil || info.CapturedChangeset.Name != "existing-changeset" {
+		t.Errorf("expected deployment.CapturedChangeset to be populated with existing changeset, got %+v", info.CapturedChangeset)
+	}
+	// Ensure the caller can still confirm+deploy against the fetched changeset
+	deployed, err := confirmAndDeployChangeset(changeset, &info, config.AWSConfig{})
+	if err != nil {
+		t.Fatalf("confirmAndDeployChangeset returned error: %v", err)
+	}
+	if !deployed {
+		t.Error("expected confirmAndDeployChangeset to return deployed=true")
+	}
+	if !deployCalled {
+		t.Error("expected deployChangesetFunc to be called")
+	}
+}

--- a/cmd/deploy_changeset_flag_test.go
+++ b/cmd/deploy_changeset_flag_test.go
@@ -118,11 +118,12 @@ func TestDeployFlags_Validate_DeployChangeset(t *testing.T) {
 	}
 }
 
-// TestDeployTemplate_DeployChangeset_SkipsCreation is a regression test for
-// T-865. When --deploy-changeset is set, deployTemplate must NOT call
-// createChangesetFunc (which creates a new changeset) and must instead
-// retrieve and execute the existing changeset named by --changeset.
-func TestDeployTemplate_DeployChangeset_SkipsCreation(t *testing.T) {
+// TestRunDeployChangesetFlow_DeployChangeset_SkipsCreation is a regression
+// test for T-865. When --deploy-changeset is set, the deploy-changeset
+// execution flow must NOT call createChangesetFunc (which creates a new
+// changeset) and must instead retrieve and execute the existing changeset
+// named by --changeset.
+func TestRunDeployChangesetFlow_DeployChangeset_SkipsCreation(t *testing.T) {
 	createCalled := false
 	fetchCalled := false
 	deployCalled := false
@@ -202,5 +203,37 @@ func TestDeployTemplate_DeployChangeset_SkipsCreation(t *testing.T) {
 	}
 	if !deployCalled {
 		t.Error("expected deployChangesetFunc to be called")
+	}
+}
+
+// TestRunDeployChangesetFlow_NilFetchReturn verifies that when
+// fetchChangesetFunc returns nil (e.g. an error path that returned after
+// calling osExitFunc, or a test stub), runDeployChangesetFlow returns nil
+// gracefully instead of panicking on a nil dereference.
+func TestRunDeployChangesetFlow_NilFetchReturn(t *testing.T) {
+	origFetch := fetchChangesetFunc
+	origShow := showChangesetFunc
+	defer func() {
+		fetchChangesetFunc = origFetch
+		showChangesetFunc = origShow
+	}()
+
+	fetchChangesetFunc = func(info *lib.DeployInfo, cfg config.AWSConfig) *lib.ChangesetInfo {
+		return nil
+	}
+	showCalled := false
+	showChangesetFunc = func(cs lib.ChangesetInfo, info lib.DeployInfo, cfg config.AWSConfig, optionalBuilder ...*output.Builder) {
+		showCalled = true
+	}
+
+	info := lib.DeployInfo{StackName: "my-stack", ChangesetName: "missing"}
+	logObj := lib.DeploymentLog{}
+
+	changeset := runDeployChangesetFlow(&info, config.AWSConfig{}, &logObj, false)
+	if changeset != nil {
+		t.Errorf("expected nil return when fetchChangesetFunc returns nil, got %+v", changeset)
+	}
+	if showCalled {
+		t.Error("showChangesetFunc must not be called when fetchChangesetFunc returns nil")
 	}
 }

--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -169,8 +169,13 @@ func createAndShowChangeset(info *lib.DeployInfo, cfg config.AWSConfig, logObj *
 // runDeployChangesetFlow retrieves an existing changeset (named by
 // --changeset), attaches it to the deployment and displays it. It is the
 // counterpart to createAndShowChangeset for the --deploy-changeset flow.
+// If fetchChangesetFunc returns nil (e.g. a test stub or an error path that
+// returned instead of exiting), the caller receives nil and should abort.
 func runDeployChangesetFlow(info *lib.DeployInfo, cfg config.AWSConfig, logObj *lib.DeploymentLog, quiet bool) *lib.ChangesetInfo {
 	changeset := fetchChangesetFunc(info, cfg)
+	if changeset == nil {
+		return nil
+	}
 	logObj.AddChangeSet(changeset)
 
 	info.CapturedChangeset = changeset

--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -25,6 +25,7 @@ var getCfnClient = func(cfg config.AWSConfig) lib.CloudFormationDescribeStacksAP
 }
 
 var createChangesetFunc = createChangeset
+var fetchChangesetFunc = fetchChangeset
 var showChangesetFunc = showChangeset
 var deleteChangesetFunc = deleteChangeset
 var deployChangesetFunc = deployChangeset
@@ -87,9 +88,13 @@ func prepareDeployment() (lib.DeployInfo, config.AWSConfig, error) {
 			return lib.DeployInfo{}, config.AWSConfig{}, err
 		}
 	}
-	setDeployTemplate(&deployment, awsCfg)
-	setDeployTags(&deployment)
-	setDeployParameters(&deployment)
+	// When deploying an existing changeset, the template/tags/parameters are
+	// already captured on the changeset itself so we skip loading them here.
+	if !deployFlags.DeployChangeset {
+		setDeployTemplate(&deployment, awsCfg)
+		setDeployTags(&deployment)
+		setDeployParameters(&deployment)
+	}
 
 	return deployment, awsCfg, nil
 }
@@ -154,6 +159,23 @@ func createAndShowChangeset(info *lib.DeployInfo, cfg config.AWSConfig, logObj *
 	info.Changeset = changeset // Maintain existing field for backwards compatibility
 
 	// Show changeset overview to stderr only when not in quiet mode
+	if !quiet {
+		showChangesetFunc(*changeset, *info, cfg)
+	}
+
+	return changeset
+}
+
+// runDeployChangesetFlow retrieves an existing changeset (named by
+// --changeset), attaches it to the deployment and displays it. It is the
+// counterpart to createAndShowChangeset for the --deploy-changeset flow.
+func runDeployChangesetFlow(info *lib.DeployInfo, cfg config.AWSConfig, logObj *lib.DeploymentLog, quiet bool) *lib.ChangesetInfo {
+	changeset := fetchChangesetFunc(info, cfg)
+	logObj.AddChangeSet(changeset)
+
+	info.CapturedChangeset = changeset
+	info.Changeset = changeset
+
 	if !quiet {
 		showChangesetFunc(*changeset, *info, cfg)
 	}

--- a/cmd/flaggroups.go
+++ b/cmd/flaggroups.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -52,6 +53,34 @@ func (f *DeployFlags) Validate() error {
 
 	if f.DeploymentFile != "" && (f.Template != "" || f.Parameters != "" || f.Tags != "") {
 		return fmt.Errorf("you can't provide a deployment file and other parameters at the same time")
+	}
+
+	if f.DeployChangeset {
+		if f.ChangesetName == "" {
+			return fmt.Errorf("--deploy-changeset requires --changeset to identify the existing change set")
+		}
+		var conflicting []string
+		if f.Dryrun {
+			conflicting = append(conflicting, "--dry-run")
+		}
+		if f.CreateChangeset {
+			conflicting = append(conflicting, "--create-changeset")
+		}
+		if f.Template != "" {
+			conflicting = append(conflicting, "--template")
+		}
+		if f.Parameters != "" {
+			conflicting = append(conflicting, "--parameters")
+		}
+		if f.Tags != "" {
+			conflicting = append(conflicting, "--tags")
+		}
+		if f.DeploymentFile != "" {
+			conflicting = append(conflicting, "--deployment-file")
+		}
+		if len(conflicting) > 0 {
+			return fmt.Errorf("--deploy-changeset cannot be combined with %s", strings.Join(conflicting, ", "))
+		}
 	}
 
 	return nil

--- a/docs/agent-notes/deploy-changeset.md
+++ b/docs/agent-notes/deploy-changeset.md
@@ -1,0 +1,53 @@
+# Deploy Changeset Mode
+
+`DeployFlags.DeployChangeset` / `--deploy-changeset` tells `fog deploy` to
+execute an existing changeset instead of creating a new one.
+
+## Flow
+
+`deployTemplate()` in `cmd/deploy.go` branches on `deployFlags.DeployChangeset`
+after `runPrechecks`:
+
+- When the flag is unset (default), it calls `createAndShowChangeset()`,
+  handles `--dry-run` and `--create-changeset`, and then deploys the freshly
+  created changeset.
+- When the flag is set, it calls `runDeployChangesetFlow()` (in
+  `cmd/deploy_helpers.go`), which uses `fetchChangesetFunc` (wraps
+  `fetchChangeset` in `cmd/deploy.go`). That helper calls
+  `DeployInfo.GetChangeset` + `AddChangeset` (in `lib/stacks.go`) to load the
+  existing changeset by name, attaches it to `deployment.Changeset` /
+  `deployment.CapturedChangeset`, and displays it with `showChangesetFunc`.
+  The flow then falls through to `confirmAndDeployChangeset` exactly like the
+  normal path.
+
+`prepareDeployment()` skips `setDeployTemplate`, `setDeployTags`,
+`setDeployParameters` when `--deploy-changeset` is set — the template and
+inputs are already captured inside the existing changeset.
+
+## Validation
+
+`DeployFlags.Validate()` (in `cmd/flaggroups.go`) enforces:
+
+- `--deploy-changeset` requires `--changeset` (so the existing changeset has a
+  name to look up).
+- `--deploy-changeset` is mutually exclusive with `--dry-run`,
+  `--create-changeset`, `--template`, `--parameters`, `--tags`, and
+  `--deployment-file`. Those flags only apply to creating a new changeset.
+
+## Tests
+
+`cmd/deploy_changeset_flag_test.go` covers:
+
+- `TestDeployFlags_Validate_DeployChangeset` — required and mutually exclusive
+  flag combinations.
+- `TestDeployTemplate_DeployChangeset_SkipsCreation` — verifies the new flow
+  uses `fetchChangesetFunc`, does not call `createChangesetFunc`, populates
+  `Changeset`/`CapturedChangeset`, and hands off to
+  `confirmAndDeployChangeset`.
+
+Tests stub `fetchChangesetFunc` / `createChangesetFunc` / `showChangesetFunc`
+just like the existing `createAndShowChangeset` tests do. When adding new
+tests around this flow, restore all function-variable pointers in `defer` to
+avoid leaking state across test files.
+
+Original bug: T-865 (`--deploy-changeset flag is ignored by deploy command`).

--- a/docs/agent-notes/deploy-changeset.md
+++ b/docs/agent-notes/deploy-changeset.md
@@ -5,12 +5,15 @@ execute an existing changeset instead of creating a new one.
 
 ## Flow
 
-`deployTemplate()` in `cmd/deploy.go` branches on `deployFlags.DeployChangeset`
-after `runPrechecks`:
+`deployTemplate()` in `cmd/deploy.go` branches on `deployFlags.DeployChangeset`:
 
-- When the flag is unset (default), it calls `createAndShowChangeset()`,
-  handles `--dry-run` and `--create-changeset`, and then deploys the freshly
-  created changeset.
+- Prechecks are skipped when `--deploy-changeset` is set. They use
+  `$TEMPLATEPATH` substitution against the local template path, which is not
+  populated in this mode (no template is loaded). Running them would produce
+  unreliable results.
+- When the flag is unset (default), it runs `runPrechecks`, then calls
+  `createAndShowChangeset()`, handles `--dry-run` and `--create-changeset`,
+  and then deploys the freshly created changeset.
 - When the flag is set, it calls `runDeployChangesetFlow()` (in
   `cmd/deploy_helpers.go`), which uses `fetchChangesetFunc` (wraps
   `fetchChangeset` in `cmd/deploy.go`). That helper calls
@@ -19,6 +22,13 @@ after `runPrechecks`:
   `deployment.CapturedChangeset`, and displays it with `showChangesetFunc`.
   The flow then falls through to `confirmAndDeployChangeset` exactly like the
   normal path.
+
+`fetchChangeset` uses `osExitFunc` (not `os.Exit` / `log.Fatalln` directly) so
+tests can intercept its failure paths, and it distinguishes retrieval errors
+(`DeployChangesetMessageRetrieveFailed`) from "no results"
+(`DeployChangesetMessageNotFound`). It returns `nil` after `osExitFunc(1)` so
+test stubs that don't actually exit don't cause a nil-dereference downstream.
+`runDeployChangesetFlow` nil-guards the fetch result for the same reason.
 
 `prepareDeployment()` skips `setDeployTemplate`, `setDeployTags`,
 `setDeployParameters` when `--deploy-changeset` is set — the template and
@@ -40,10 +50,13 @@ inputs are already captured inside the existing changeset.
 
 - `TestDeployFlags_Validate_DeployChangeset` — required and mutually exclusive
   flag combinations.
-- `TestDeployTemplate_DeployChangeset_SkipsCreation` — verifies the new flow
-  uses `fetchChangesetFunc`, does not call `createChangesetFunc`, populates
-  `Changeset`/`CapturedChangeset`, and hands off to
+- `TestRunDeployChangesetFlow_DeployChangeset_SkipsCreation` — verifies the
+  new flow uses `fetchChangesetFunc`, does not call `createChangesetFunc`,
+  populates `Changeset`/`CapturedChangeset`, and hands off to
   `confirmAndDeployChangeset`.
+- `TestRunDeployChangesetFlow_NilFetchReturn` — verifies that if
+  `fetchChangesetFunc` returns nil the flow bails out without dereferencing
+  the nil changeset.
 
 Tests stub `fetchChangesetFunc` / `createChangesetFunc` / `showChangesetFunc`
 just like the existing `createAndShowChangeset` tests do. When adding new

--- a/lib/texts/deployments.go
+++ b/lib/texts/deployments.go
@@ -64,6 +64,7 @@ const (
 	DeployChangesetMessageConsole           DeployChangesetMessage = "If you want to look at the change set in the Console, please go to"
 	DeployChangesetMessageCreationFailed    DeployChangesetMessage = "Something went wrong when trying to create the change set"
 	DeployChangesetMessageRetrieveFailed    DeployChangesetMessage = "Something went wrong when trying to retrieve change set %v"
+	DeployChangesetMessageNotFound          DeployChangesetMessage = "Change set %v was not found; verify the change set and stack names"
 	DeployChangesetMessageDeleteConfirm     DeployChangesetMessage = "Do you want to delete this change set?"
 	DeployChangesetMessageDeleteFailed      DeployChangesetMessage = "Something went wrong while trying to delete the change set"
 	DeployChangesetMessageDeployConfirm     DeployChangesetMessage = "Do you want to deploy this change set?"


### PR DESCRIPTION
## Summary

Fixes T-865. The `--deploy-changeset` flag was advertised as "Deploy a specific change set" but `deployTemplate()` never read `deployFlags.DeployChangeset` — it always created a fresh changeset before deploying. This broke the documented review workflow where a user first runs `fog deploy --create-changeset`, reviews the changeset in the Console, then deploys it with `fog deploy --deploy-changeset`.

## Changes

- `cmd/deploy.go` — add `fetchChangeset` (via `DeployInfo.GetChangeset` + `AddChangeset`) and branch `deployTemplate` on `deployFlags.DeployChangeset` so the existing changeset is loaded instead of a new one being created.
- `cmd/deploy_helpers.go` — add `fetchChangesetFunc` and `runDeployChangesetFlow` (mirroring `createChangesetFunc` / `createAndShowChangeset`); skip `setDeployTemplate` / `setDeployTags` / `setDeployParameters` in `prepareDeployment` when `--deploy-changeset` is set because the changeset already captures those inputs.
- `cmd/flaggroups.go` — validate that `--deploy-changeset` requires `--changeset` and is mutually exclusive with `--dry-run`, `--create-changeset`, `--template`, `--parameters`, `--tags`, `--deployment-file`.
- `cmd/deploy_changeset_flag_test.go` — regression tests for validation and the new flow (confirms `createChangesetFunc` is not called when `--deploy-changeset` is set).
- `docs/agent-notes/deploy-changeset.md` — updated note describing the corrected behaviour.

## Test plan

- [x] `go test ./...` (unit) passes
- [x] `INTEGRATION=1 go test ./... -count=1` passes
- [x] `golangci-lint run ./...` clean
- [x] `TestDeployFlags_Validate_DeployChangeset` and `TestDeployTemplate_DeployChangeset_SkipsCreation` fail against the pre-fix code and pass after the fix