### PR TITLE
Fix T-888: Parameterized NACL Protocol And Egress Values May Not Resolve In Drift Checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 ### Fixed
+- Fixed drift detection for parameterized Network ACL entries so `Protocol`, `Egress`, and `RuleAction` `Ref` values resolve correctly instead of falling back to empty/default values
 - Fixed glob-style filters in stack, export, resource, and dependency commands treating regex metacharacters (`.`, `+`, `[`, `?`, etc.) as regex operators instead of literal characters, causing false matches on names containing those characters
 - Fixed `writeLogToFile` silently discarding `file.Close()` errors due to unnamed return value in deferred close handler
 

--- a/lib/template.go
+++ b/lib/template.go
@@ -396,15 +396,15 @@ func FilterRoutesByLogicalId(logicalId string, template CfnTemplateBody, params 
 
 // NaclResourceToNaclEntry converts a CloudFormation NACL resource to an EC2 NetworkAclEntry
 func NaclResourceToNaclEntry(resource CfnTemplateResource, params []cfntypes.Parameter) types.NetworkAclEntry {
-	protocol := extractProtocol(resource.Properties)
+	protocol := extractProtocol(resource.Properties, params)
 	rulenr := extractRuleNumber(resource.Properties, params)
 	cidrblock := extractCidrBlock(resource.Properties, "CidrBlock", params)
 	ipv6cidrblock := ""
 	if cidrblock == "" {
 		ipv6cidrblock = extractCidrBlock(resource.Properties, "Ipv6CidrBlock", params)
 	}
-	ruleaction := extractRuleAction(resource.Properties)
-	egress := extractEgressFlag(resource.Properties)
+	ruleaction := extractRuleAction(resource.Properties, params)
+	egress := extractEgressFlag(resource.Properties, params)
 
 	result := types.NetworkAclEntry{
 		Egress:     &egress,
@@ -457,24 +457,40 @@ func extractRuleNumber(properties map[string]any, params []cfntypes.Parameter) i
 	return 0
 }
 
-// extractEgressFlag safely extracts the egress flag from NACL properties
-func extractEgressFlag(properties map[string]any) bool {
-	if egress, ok := properties["Egress"].(bool); ok {
-		return egress
+// extractEgressFlag safely extracts the egress flag from NACL properties,
+// resolving {"Ref": "ParamName"} values through stack parameters.
+func extractEgressFlag(properties map[string]any, params []cfntypes.Parameter) bool {
+	switch value := properties["Egress"].(type) {
+	case bool:
+		return value
+	case map[string]any:
+		if refname, ok := value["Ref"].(string); ok {
+			if resolved := resolveParameterValue(refname, params); resolved != "" {
+				if parsed, err := strconv.ParseBool(resolved); err == nil {
+					return parsed
+				}
+			}
+		}
 	}
 	return false
 }
 
-// extractProtocol extracts the protocol from NACL properties
-func extractProtocol(properties map[string]any) string {
+// extractProtocol extracts the protocol from NACL properties, resolving
+// {"Ref": "ParamName"} values through stack parameters.
+func extractProtocol(properties map[string]any, params []cfntypes.Parameter) string {
 	switch value := properties["Protocol"].(type) {
 	case string:
 		return value
 	case float64:
 		return strconv.Itoa(int(value))
+	case map[string]any:
+		if refname, ok := value["Ref"].(string); ok {
+			return resolveParameterValue(refname, params)
+		}
 	default:
 		return ""
 	}
+	return ""
 }
 
 // extractCidrBlock extracts a CIDR block from properties, resolving parameter references
@@ -512,11 +528,19 @@ func resolveParameterValue(refname string, params []cfntypes.Parameter) string {
 	return ""
 }
 
-// extractRuleAction extracts the rule action from NACL properties
-func extractRuleAction(properties map[string]any) types.RuleAction {
-	if ruleactionprop, ok := properties["RuleAction"].(string); ok {
-		if ruleactionprop == string(types.RuleActionDeny) {
+// extractRuleAction extracts the rule action from NACL properties, resolving
+// {"Ref": "ParamName"} values through stack parameters.
+func extractRuleAction(properties map[string]any, params []cfntypes.Parameter) types.RuleAction {
+	switch value := properties["RuleAction"].(type) {
+	case string:
+		if value == string(types.RuleActionDeny) {
 			return types.RuleActionDeny
+		}
+	case map[string]any:
+		if refname, ok := value["Ref"].(string); ok {
+			if resolveParameterValue(refname, params) == string(types.RuleActionDeny) {
+				return types.RuleActionDeny
+			}
 		}
 	}
 	return types.RuleActionAllow

--- a/lib/template.go
+++ b/lib/template.go
@@ -487,10 +487,10 @@ func extractProtocol(properties map[string]any, params []cfntypes.Parameter) str
 		if refname, ok := value["Ref"].(string); ok {
 			return resolveParameterValue(refname, params)
 		}
+		return ""
 	default:
 		return ""
 	}
-	return ""
 }
 
 // extractCidrBlock extracts a CIDR block from properties, resolving parameter references

--- a/lib/template_helpers_test.go
+++ b/lib/template_helpers_test.go
@@ -83,6 +83,12 @@ func TestExtractRuleNumber(t *testing.T) {
 
 // TestExtractEgressFlag tests the safe extraction of egress flags from NACL properties
 func TestExtractEgressFlag(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: aws.String("EgressParam"), ParameterValue: aws.String("true")},
+		{ParameterKey: aws.String("ResolvedEgressParam"), ResolvedValue: aws.String("false"), ParameterValue: aws.String("true")},
+		{ParameterKey: aws.String("InvalidEgressParam"), ParameterValue: aws.String("not-a-bool")},
+	}
+
 	tests := []struct {
 		name       string
 		properties map[string]any
@@ -108,11 +114,36 @@ func TestExtractEgressFlag(t *testing.T) {
 			properties: map[string]any{"Egress": "true"},
 			want:       false,
 		},
+		{
+			name:       "parameter reference resolves via ParameterValue",
+			properties: map[string]any{"Egress": map[string]any{"Ref": "EgressParam"}},
+			want:       true,
+		},
+		{
+			name:       "parameter reference prefers ResolvedValue over ParameterValue",
+			properties: map[string]any{"Egress": map[string]any{"Ref": "ResolvedEgressParam"}},
+			want:       false,
+		},
+		{
+			name:       "parameter reference with invalid bool value",
+			properties: map[string]any{"Egress": map[string]any{"Ref": "InvalidEgressParam"}},
+			want:       false,
+		},
+		{
+			name:       "parameter reference to unknown parameter",
+			properties: map[string]any{"Egress": map[string]any{"Ref": "Unknown"}},
+			want:       false,
+		},
+		{
+			name:       "map without Ref key",
+			properties: map[string]any{"Egress": map[string]any{"Fn::Sub": "something"}},
+			want:       false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractEgressFlag(tt.properties)
+			got := extractEgressFlag(tt.properties, params)
 			if got != tt.want {
 				t.Errorf("extractEgressFlag() = %v, want %v", got, tt.want)
 			}
@@ -122,6 +153,11 @@ func TestExtractEgressFlag(t *testing.T) {
 
 // TestExtractProtocol tests protocol extraction from NACL properties
 func TestExtractProtocol(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: aws.String("ProtocolParam"), ParameterValue: aws.String("6")},
+		{ParameterKey: aws.String("ResolvedProtocolParam"), ResolvedValue: aws.String("-1"), ParameterValue: aws.String("17")},
+	}
+
 	tests := []struct {
 		name       string
 		properties map[string]any
@@ -152,11 +188,31 @@ func TestExtractProtocol(t *testing.T) {
 			properties: map[string]any{"Protocol": float64(-1)},
 			want:       "-1",
 		},
+		{
+			name:       "parameter reference resolves via ParameterValue",
+			properties: map[string]any{"Protocol": map[string]any{"Ref": "ProtocolParam"}},
+			want:       "6",
+		},
+		{
+			name:       "parameter reference prefers ResolvedValue over ParameterValue",
+			properties: map[string]any{"Protocol": map[string]any{"Ref": "ResolvedProtocolParam"}},
+			want:       "-1",
+		},
+		{
+			name:       "parameter reference to unknown parameter",
+			properties: map[string]any{"Protocol": map[string]any{"Ref": "Unknown"}},
+			want:       "",
+		},
+		{
+			name:       "map without Ref key",
+			properties: map[string]any{"Protocol": map[string]any{"Fn::Sub": "something"}},
+			want:       "",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractProtocol(tt.properties)
+			got := extractProtocol(tt.properties, params)
 			if got != tt.want {
 				t.Errorf("extractProtocol() = %v, want %v", got, tt.want)
 			}
@@ -269,6 +325,11 @@ func TestExtractCidrBlock(t *testing.T) {
 
 // TestExtractRuleAction tests rule action extraction
 func TestExtractRuleAction(t *testing.T) {
+	params := []cfntypes.Parameter{
+		{ParameterKey: aws.String("RuleActionParam"), ParameterValue: aws.String("deny")},
+		{ParameterKey: aws.String("ResolvedRuleActionParam"), ResolvedValue: aws.String("deny"), ParameterValue: aws.String("allow")},
+	}
+
 	tests := []struct {
 		name       string
 		properties map[string]any
@@ -294,11 +355,31 @@ func TestExtractRuleAction(t *testing.T) {
 			properties: map[string]any{"RuleAction": 123},
 			want:       types.RuleActionAllow,
 		},
+		{
+			name:       "parameter reference resolves via ParameterValue",
+			properties: map[string]any{"RuleAction": map[string]any{"Ref": "RuleActionParam"}},
+			want:       types.RuleActionDeny,
+		},
+		{
+			name:       "parameter reference prefers ResolvedValue over ParameterValue",
+			properties: map[string]any{"RuleAction": map[string]any{"Ref": "ResolvedRuleActionParam"}},
+			want:       types.RuleActionDeny,
+		},
+		{
+			name:       "parameter reference to unknown parameter defaults to allow",
+			properties: map[string]any{"RuleAction": map[string]any{"Ref": "Unknown"}},
+			want:       types.RuleActionAllow,
+		},
+		{
+			name:       "map without Ref key defaults to allow",
+			properties: map[string]any{"RuleAction": map[string]any{"Fn::Sub": "something"}},
+			want:       types.RuleActionAllow,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractRuleAction(tt.properties)
+			got := extractRuleAction(tt.properties, params)
 			if got != tt.want {
 				t.Errorf("extractRuleAction() = %v, want %v", got, tt.want)
 			}

--- a/lib/template_test.go
+++ b/lib/template_test.go
@@ -73,6 +73,9 @@ func TestNaclResourceToNaclEntry(t *testing.T) {
 	params := []cfntypes.Parameter{
 		{ParameterKey: aws.String("CIDR"), ParameterValue: aws.String("10.0.0.0/24")},
 		{ParameterKey: aws.String("IPV6"), ParameterValue: aws.String("::/0")},
+		{ParameterKey: aws.String("ProtocolParam"), ParameterValue: aws.String("-1")},
+		{ParameterKey: aws.String("EgressParam"), ParameterValue: aws.String("true")},
+		{ParameterKey: aws.String("RuleActionParam"), ParameterValue: aws.String("deny")},
 	}
 
 	// IPv4 entry using numeric Protocol and nested maps for PortRange and ICMP
@@ -128,6 +131,33 @@ func TestNaclResourceToNaclEntry(t *testing.T) {
 	got2 := NaclResourceToNaclEntry(resource2, params)
 	if !reflect.DeepEqual(got2, expected2) {
 		t.Errorf("NaclResourceToNaclEntry() = %#v, want %#v", got2, expected2)
+	}
+
+	// Parameterized entry ensures Ref-based values are resolved before drift
+	// comparison so protocol, egress, and rule action do not silently fall back
+	// to zero values.
+	resource3 := CfnTemplateResource{
+		Type: "AWS::EC2::NetworkAclEntry",
+		Properties: map[string]any{
+			"Protocol":   map[string]any{"Ref": "ProtocolParam"},
+			"RuleNumber": 120.0,
+			"CidrBlock":  map[string]any{"Ref": "CIDR"},
+			"RuleAction": map[string]any{"Ref": "RuleActionParam"},
+			"Egress":     map[string]any{"Ref": "EgressParam"},
+		},
+	}
+
+	expected3 := types.NetworkAclEntry{
+		CidrBlock:  aws.String("10.0.0.0/24"),
+		Egress:     aws.Bool(true),
+		Protocol:   aws.String("-1"),
+		RuleAction: types.RuleActionDeny,
+		RuleNumber: aws.Int32(120),
+	}
+
+	got3 := NaclResourceToNaclEntry(resource3, params)
+	if !reflect.DeepEqual(got3, expected3) {
+		t.Errorf("NaclResourceToNaclEntry() = %#v, want %#v", got3, expected3)
 	}
 }
 

--- a/specs/bugfixes/parameterized-nacl-protocol-and-egress-values-may-not-resolve-in-drift-checks/report.md
+++ b/specs/bugfixes/parameterized-nacl-protocol-and-egress-values-may-not-resolve-in-drift-checks/report.md
@@ -1,0 +1,87 @@
+# Bugfix Report: Parameterized NACL protocol and egress values may not resolve in drift checks
+
+**Date:** 2026-04-28
+**Status:** Fixed
+
+## Description of the Issue
+
+Network ACL drift checks converted CloudFormation template entries into EC2 SDK entries without resolving `Ref` values for some scalar properties. When `Protocol`, `Egress`, or similar direct NACL properties were parameterized, the helper functions silently returned zero values instead of the resolved parameter value.
+
+**Reproduction steps:**
+1. Define an `AWS::EC2::NetworkAclEntry` whose `Protocol`, `Egress`, or `RuleAction` property is set via `{"Ref": "ParamName"}`.
+2. Run the template-to-EC2 conversion used by drift detection.
+3. Observe that unresolved values fall back to `""`, `false`, or `allow` instead of the parameter value.
+
+**Impact:** Drift checks can misclassify parameterized NACL entries, hiding real drift or reporting incorrect differences.
+
+## Investigation Summary
+
+A targeted review of the NACL conversion helpers in `lib/template.go` showed that `extractRuleNumber` and `extractCidrBlock` already resolved `Ref` parameters, but sibling scalar extractors still only handled literal values.
+
+- **Symptoms examined:** Parameterized NACL protocol and egress values disappeared during conversion and defaulted to zero values.
+- **Code inspected:** `lib/template.go`, `lib/template_helpers_test.go`, and `lib/template_test.go`.
+- **Hypotheses tested:** Confirmed with a regression case in `TestNaclResourceToNaclEntry` that `Protocol`, `Egress`, and `RuleAction` parameter references were not resolved.
+
+## Discovered Root Cause
+
+The NACL helper functions for direct scalar properties only type-switched on literal Go values (`string`, `float64`, `bool`). CloudFormation parameter references are decoded as `map[string]any{"Ref": ...}`, so those helpers skipped the value entirely and returned their defaults.
+
+**Defect type:** Logic error
+
+**Why it occurred:** T-834 fixed `extractRuleNumber`, but the same `Ref`-resolution pattern was not applied to sibling helpers that convert NACL properties.
+
+**Contributing factors:** Default return values (`""`, `false`, `allow`) are valid-looking outputs, so the bug was easy to miss without parameterized regression coverage.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/template.go:399-407` - Passed stack parameters into all direct NACL scalar extractors during `NetworkAclEntry` conversion.
+- `lib/template.go:460-546` - Taught `extractEgressFlag`, `extractProtocol`, and `extractRuleAction` to resolve `{"Ref": "ParamName"}` values via `resolveParameterValue`.
+- `lib/template_helpers_test.go:84-388` - Added helper-level regression cases for parameterized egress, protocol, and rule action values, including resolved-value precedence and fallback paths.
+- `lib/template_test.go:72-162` - Added an end-to-end regression case proving parameterized NACL entries are converted correctly for drift comparison.
+
+**Approach rationale:** Mirror the existing `extractRuleNumber` and `extractCidrBlock` behaviour so all direct NACL scalar properties use the same parameter-resolution strategy. This keeps the fix local to the drift-conversion helpers and avoids changing unrelated CloudFormation parsing paths.
+
+**Alternatives considered:**
+- Resolve parameter references earlier during full template unmarshalling - not chosen because the bug is isolated to NACL drift conversion and the helper-level fix is safer and smaller.
+
+## Regression Test
+
+**Test file:** `lib/template_helpers_test.go`, `lib/template_test.go`
+**Test name:** `TestExtractEgressFlag`, `TestExtractProtocol`, `TestExtractRuleAction`, `TestNaclResourceToNaclEntry`
+
+**What it verifies:** Parameterized NACL scalar properties resolve `Ref` values correctly at both helper level and during full `NetworkAclEntry` construction for drift checks.
+
+**Run command:** `go test ./lib -run 'TestNaclResourceToNaclEntry|TestExtractEgressFlag|TestExtractProtocol|TestExtractRuleAction' -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/template.go` | NACL property extraction logic for drift conversion |
+| `lib/template_helpers_test.go` | Helper-level regression coverage for parameterized NACL properties |
+| `lib/template_test.go` | End-to-end regression for parameterized NACL entry conversion |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Added a failing regression test before implementation to confirm the bug in the NACL conversion path.
+- Verified the helper-level and end-to-end regression tests pass after the fix.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Reuse shared `Ref`-resolution helpers for CloudFormation scalar properties instead of per-field literal-only parsing.
+- Add parameter-reference test cases whenever a helper extracts CloudFormation resource properties.
+- Review sibling extractors when fixing one member of a helper family.
+
+## Related
+
+- Transit ticket `T-888`
+- Follow-up to `T-834`
+- Source: PR #181 review by `claude[bot]`


### PR DESCRIPTION
Summary:
- resolve Ref-based NACL scalar properties during drift conversion for protocol, egress, and rule action
- add helper-level regressions for parameterized protocol, egress, and rule action extraction
- add an end-to-end NACL conversion regression and bugfix report under specs/bugfixes

Root cause:
The NACL drift helpers only handled literal string, float64, and bool values. Parameterized CloudFormation properties are decoded as Ref maps, so the helpers silently returned default values instead of resolving the parameter.

Testing:
- go test ./lib -run TestNaclResourceToNaclEntry -run TestExtractEgressFlag -run TestExtractProtocol -run TestExtractRuleAction -v
- go test ./... -v
- golangci-lint run

See specs/bugfixes/parameterized-nacl-protocol-and-egress-values-may-not-resolve-in-drift-checks/report.md