### PR TITLE
Fix T-1003: Handle Final Stack Lookup Failures In Deploy Result Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Unreleased
 
 ### Fixed
 - Fixed drift detection for parameterized Network ACL entries so `Protocol`, `Egress`, and `RuleAction` `Ref` values resolve correctly instead of falling back to empty/default values
+- Fixed deploy result logging to record a failed deployment and emit failure output when the final post-deploy stack lookup fails instead of exiting before finalizing the deployment log
 - Fixed glob-style filters in stack, export, resource, and dependency commands treating regex metacharacters (`.`, `+`, `[`, `?`, etc.) as regex operators instead of literal characters, causing false matches on names containing those characters
 - Fixed `writeLogToFile` silently discarding `file.Close()` errors due to unnamed return value in deferred close handler
 

--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"time"
@@ -217,8 +216,26 @@ func printDeploymentResults(info *lib.DeployInfo, cfg config.AWSConfig, logObj *
 	svc := getCfnClient(cfg)
 	resultStack, err := getFreshStackFunc(info, svc)
 	if err != nil {
+		info.DeploymentError = fmt.Errorf("failed to retrieve final stack state: %w", err)
+		logObj.StatusDescription = info.DeploymentError.Error()
+
+		failures := []map[string]any{{
+			"CfnName": info.StackName,
+			"Type":    "AWS::CloudFormation::Stack",
+			"Status":  "POST_DEPLOY_LOOKUP_FAILED",
+			"Reason":  err.Error(),
+		}}
+
 		printMessage(formatError(string(texts.DeployStackMessageRetrievePostFailed)))
-		log.Fatalln(err.Error())
+		if err := logObj.Failed(failures); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to write deployment log: %v\n", err)
+		}
+
+		eventsClient, _ := svc.(lib.CloudFormationDescribeStackEventsAPI)
+		if err := outputFailureResult(info, eventsClient); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Failed to generate output: %v\n", err)
+		}
+		return
 	}
 
 	// Capture final stack state for output generation

--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -35,6 +35,8 @@ var deleteStackIfNewFunc = deleteStackIfNew
 // osExitFunc allows tests to intercept os.Exit calls in command handlers.
 var osExitFunc = os.Exit
 
+const postDeployLookupFailedStatus = "POST_DEPLOY_LOOKUP_FAILED"
+
 var getFreshStackFunc = func(info *lib.DeployInfo, svc lib.CloudFormationDescribeStacksAPI) (types.Stack, error) {
 	return info.GetFreshStack(context.Background(), svc)
 }
@@ -219,10 +221,12 @@ func printDeploymentResults(info *lib.DeployInfo, cfg config.AWSConfig, logObj *
 		info.DeploymentError = fmt.Errorf("failed to retrieve final stack state: %w", err)
 		logObj.StatusDescription = info.DeploymentError.Error()
 
+		// This is a synthetic status because CloudFormation did not return a
+		// definitive post-deploy stack status for us to record.
 		failures := []map[string]any{{
 			"CfnName": info.StackName,
 			"Type":    "AWS::CloudFormation::Stack",
-			"Status":  "POST_DEPLOY_LOOKUP_FAILED",
+			"Status":  postDeployLookupFailedStatus,
 			"Reason":  err.Error(),
 		}}
 
@@ -231,8 +235,9 @@ func printDeploymentResults(info *lib.DeployInfo, cfg config.AWSConfig, logObj *
 			fmt.Fprintf(os.Stderr, "Warning: Failed to write deployment log: %v\n", err)
 		}
 
-		eventsClient, _ := svc.(lib.CloudFormationDescribeStackEventsAPI)
-		if err := outputFailureResult(info, eventsClient); err != nil {
+		// Do not auto-delete new stacks on this path: without a successful final
+		// lookup we cannot safely determine whether cleanup is appropriate.
+		if err := outputFailureResult(info, cfg.CloudformationClient()); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: Failed to generate output: %v\n", err)
 		}
 		return

--- a/cmd/deploy_helpers_test.go
+++ b/cmd/deploy_helpers_test.go
@@ -2,7 +2,11 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -764,6 +768,98 @@ func TestPrintDeploymentResults(t *testing.T) {
 				t.Errorf("expected deleteStackIfNew called=%v, got %v", tc.expectDeleteNewCall, deleteNewCalled)
 			}
 		})
+	}
+}
+
+func TestPrintDeploymentResults_HandlesFinalStackLookupFailure(t *testing.T) {
+	const resultMarker = "__PRINT_DEPLOYMENT_RESULTS_RESULT__="
+	const subprocessEnv = "FOG_TEST_PRINT_DEPLOYMENT_RESULTS_LOOKUP_FAILURE"
+
+	if os.Getenv(subprocessEnv) == "1" {
+		origGetStack := getFreshStackFunc
+		origGetClient := getCfnClient
+		defer func() {
+			getFreshStackFunc = origGetStack
+			getCfnClient = origGetClient
+		}()
+
+		getFreshStackFunc = func(info *lib.DeployInfo, svc lib.CloudFormationDescribeStacksAPI) (types.Stack, error) {
+			return types.Stack{}, errors.New("lookup failed")
+		}
+		getCfnClient = func(cfg config.AWSConfig) lib.CloudFormationDescribeStacksAPI {
+			return testutil.NewMockCFNClient()
+		}
+
+		viper.Reset()
+		viper.Set("logging.enabled", false)
+
+		info := lib.DeployInfo{StackName: "test-stack"}
+		logObj := lib.DeploymentLog{}
+
+		printDeploymentResults(&info, config.AWSConfig{}, &logObj)
+
+		payload, err := json.Marshal(struct {
+			Status            string `json:"status"`
+			DeploymentError   string `json:"deploymentError"`
+			HasFinalStack     bool   `json:"hasFinalStack"`
+			RecordedFailures  int    `json:"recordedFailures"`
+			StatusDescription string `json:"statusDescription"`
+		}{
+			Status:            string(logObj.Status),
+			HasFinalStack:     info.FinalStackState != nil,
+			RecordedFailures:  len(logObj.Failures),
+			StatusDescription: logObj.StatusDescription,
+			DeploymentError: func() string {
+				if info.DeploymentError == nil {
+					return ""
+				}
+				return info.DeploymentError.Error()
+			}(),
+		})
+		if err != nil {
+			t.Fatalf("failed to marshal subprocess result: %v", err)
+		}
+
+		fmt.Fprintf(os.Stdout, "\n%s%s\n", resultMarker, payload)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestPrintDeploymentResults_HandlesFinalStackLookupFailure$")
+	cmd.Env = append(os.Environ(), subprocessEnv+"=1")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected subprocess to complete without fatal exit, got %v\noutput:\n%s", err, output)
+	}
+
+	idx := strings.LastIndex(string(output), resultMarker)
+	if idx == -1 {
+		t.Fatalf("expected subprocess result marker in output:\n%s", output)
+	}
+	resultLine := strings.SplitN(string(output[idx+len(resultMarker):]), "\n", 2)[0]
+
+	var result struct {
+		Status            string `json:"status"`
+		DeploymentError   string `json:"deploymentError"`
+		HasFinalStack     bool   `json:"hasFinalStack"`
+		RecordedFailures  int    `json:"recordedFailures"`
+		StatusDescription string `json:"statusDescription"`
+	}
+	if err := json.Unmarshal([]byte(resultLine), &result); err != nil {
+		t.Fatalf("failed to parse subprocess result: %v\noutput:\n%s", err, output[idx:])
+	}
+
+	if result.Status != string(lib.DeploymentLogStatusFailed) {
+		t.Fatalf("expected failed deployment log status, got %q", result.Status)
+	}
+	if !strings.Contains(result.DeploymentError, "lookup failed") {
+		t.Fatalf("expected deployment error to include lookup failure, got %q", result.DeploymentError)
+	}
+	if result.HasFinalStack {
+		t.Fatal("expected final stack state to remain unset when lookup fails")
+	}
+	if result.RecordedFailures == 0 {
+		t.Fatal("expected deployment log to record a failure entry")
 	}
 }
 

--- a/cmd/deploy_helpers_test.go
+++ b/cmd/deploy_helpers_test.go
@@ -855,6 +855,9 @@ func TestPrintDeploymentResults_HandlesFinalStackLookupFailure(t *testing.T) {
 	if !strings.Contains(result.DeploymentError, "lookup failed") {
 		t.Fatalf("expected deployment error to include lookup failure, got %q", result.DeploymentError)
 	}
+	if !strings.Contains(result.StatusDescription, "lookup failed") {
+		t.Fatalf("expected status description to include lookup failure, got %q", result.StatusDescription)
+	}
 	if result.HasFinalStack {
 		t.Fatal("expected final stack state to remain unset when lookup fails")
 	}

--- a/specs/bugfixes/handle-final-stack-lookup-failures-in-deploy-result-logging/report.md
+++ b/specs/bugfixes/handle-final-stack-lookup-failures-in-deploy-result-logging/report.md
@@ -1,0 +1,83 @@
+# Bugfix Report: Handle final stack lookup failures in deploy result logging
+
+**Date:** 2026-04-28
+**Status:** Fixed
+
+## Description of the Issue
+
+`printDeploymentResults` fetched the final stack state after a deployment and treated lookup errors as fatal process exits. When that happened, the command stopped before writing a final `SUCCESS` or `FAILED` deployment log entry.
+
+**Reproduction steps:**
+1. Execute a deployment that reaches `printDeploymentResults`.
+2. Make `getFreshStackFunc` return an error while fetching the post-deploy stack state.
+3. Observe the helper print an error and terminate before `DeploymentLog.Failed()` runs.
+
+**Impact:** Deployment history could miss the final status for a failed deployment-result path, making logs incomplete and violating the helper's documented behaviour.
+
+## Investigation Summary
+
+The inspection focused on the post-deploy result handling path and how deployment logs are finalized.
+
+- **Symptoms examined:** abrupt termination on final stack lookup failure, missing deployment log status, missing regression coverage for the lookup-error path
+- **Code inspected:** `cmd/deploy_helpers.go`, `cmd/deploy_helpers_test.go`, `cmd/deploy_integration_test.go`, `lib/logging.go`, `cmd/deploy_output.go`
+- **Hypotheses tested:** whether the helper wrote a failure log before exiting, whether failure output could be rendered without a final stack state, and whether existing tests exercised the error branch
+
+## Discovered Root Cause
+
+The `getFreshStackFunc` error branch in `printDeploymentResults` called `log.Fatalln`, which terminated the process immediately after printing an error. Because that branch never called `DeploymentLog.Failed()`, the deployment log was left without a final status.
+
+**Defect type:** Error handling / control-flow error
+
+**Why it occurred:** The helper had explicit success and rollback handling, but the final stack lookup failure path bypassed the same logging lifecycle and used process termination instead of handled failure reporting.
+
+**Contributing factors:** Existing tests only covered successful final stack retrieval, so the fatal-exit path was not protected by regression coverage.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/deploy_helpers.go` - replace the fatal exit on final stack lookup failure with handled failure reporting: set `DeploymentError`, record a failed deployment log entry, emit failure output, and return.
+- `cmd/deploy_helpers_test.go` - add a subprocess regression test that proves the lookup-error path no longer exits abruptly and now records a failed deployment log entry.
+
+**Approach rationale:** The fix stays local to deployment result handling and aligns the lookup-error branch with the existing pattern used for other deployment failures.
+
+**Alternatives considered:**
+- Return an error from `printDeploymentResults` and handle it in the caller - not chosen because it would require broader signature and call-site changes for a localized bug.
+- Keep an exit after writing the log - not chosen because this path is now handled like other deployment-result failures and no longer needs abrupt termination.
+
+## Regression Test
+
+**Test file:** `cmd/deploy_helpers_test.go`
+**Test name:** `TestPrintDeploymentResults_HandlesFinalStackLookupFailure`
+
+**What it verifies:** A final stack lookup error is handled without a fatal exit, records a failed deployment log entry, and preserves the deployment error on the result object.
+
+**Run command:** `go test ./cmd -run TestPrintDeploymentResults_HandlesFinalStackLookupFailure -count=1`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/deploy_helpers.go` | Handle final stack lookup errors as deployment-result failures instead of fatal exits |
+| `cmd/deploy_helpers_test.go` | Add regression coverage for the `getFreshStackFunc` error path |
+| `specs/bugfixes/handle-final-stack-lookup-failures-in-deploy-result-logging/report.md` | Document investigation, root cause, fix, and verification |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Verified the regression via a subprocess test that reproduces the old fatal-exit behaviour safely and confirms the helper now returns with a failed deployment log status.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Treat deploy-result edge cases the same way as normal deployment failures so the deployment log is always finalized.
+- Add focused regression tests for all non-success branches in lifecycle helpers that are documented to always emit a final status.
+- Prefer injectable exit hooks or returned errors over direct fatal logging in code paths that still need cleanup or auditing.
+
+## Related
+
+- Transit ticket `T-1003`


### PR DESCRIPTION
## Summary
- handle final stack lookup errors in deploy result logging as failed deployment results instead of fatal exits
- record a failed deployment log entry and emit failure output when post-deploy stack retrieval fails
- add a regression test and bugfix report for the getFreshStackFunc error path

## Root cause
`printDeploymentResults` called `log.Fatalln` when the final stack lookup failed, which exited before `DeploymentLog.Failed()` could finalize the deployment log.

## Testing
- go test ./...
- INTEGRATION=1 go test ./...
- golangci-lint run

## Report
- specs/bugfixes/handle-final-stack-lookup-failures-in-deploy-result-logging/report.md