### PR TITLE
Fix T-898: Fix Nil-Unsafe Test Assertions Blocking Lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Unreleased
 ### Fixed
 - Fixed drift detection for parameterized Network ACL entries so `Protocol`, `Egress`, and `RuleAction` `Ref` values resolve correctly instead of falling back to empty/default values
 - Fixed deploy result logging to record a failed deployment and emit failure output when the final post-deploy stack lookup fails instead of exiting before finalizing the deployment log
+- Fixed nil-unsafe test assertion helpers to return after fatal nil checks and report `<nil>` values for malformed stack parameters, outputs, and tags instead of panicking
 - Fixed glob-style filters in stack, export, resource, and dependency commands treating regex metacharacters (`.`, `+`, `[`, `?`, etc.) as regex operators instead of literal characters, causing false matches on names containing those characters
 - Fixed `writeLogToFile` silently discarding `file.Close()` errors due to unnamed return value in deferred close handler
 

--- a/lib/testutil/assertions.go
+++ b/lib/testutil/assertions.go
@@ -54,6 +54,7 @@ func AssertStackStatus(t *testing.T, stack *types.Stack, expectedStatus types.St
 
 	if stack == nil {
 		t.Fatal("Stack is nil")
+		return
 	}
 
 	if stack.StackStatus != expectedStatus {
@@ -92,6 +93,7 @@ func AssertStackParameter(t *testing.T, stack *types.Stack, key, expectedValue s
 
 	if stack == nil {
 		t.Fatal("Stack is nil")
+		return
 	}
 
 	for _, param := range stack.Parameters {
@@ -101,7 +103,7 @@ func AssertStackParameter(t *testing.T, stack *types.Stack, key, expectedValue s
 			}
 			t.Errorf("Parameter %s value mismatch\nGot: %v\nExpected: %s",
 				key,
-				*param.ParameterValue,
+				stringValueOrNil(param.ParameterValue),
 				expectedValue)
 			return
 		}
@@ -116,6 +118,7 @@ func AssertStackOutput(t *testing.T, stack *types.Stack, key, expectedValue stri
 
 	if stack == nil {
 		t.Fatal("Stack is nil")
+		return
 	}
 
 	for _, output := range stack.Outputs {
@@ -125,7 +128,7 @@ func AssertStackOutput(t *testing.T, stack *types.Stack, key, expectedValue stri
 			}
 			t.Errorf("Output %s value mismatch\nGot: %v\nExpected: %s",
 				key,
-				*output.OutputValue,
+				stringValueOrNil(output.OutputValue),
 				expectedValue)
 			return
 		}
@@ -140,6 +143,7 @@ func AssertStackTag(t *testing.T, stack *types.Stack, key, expectedValue string)
 
 	if stack == nil {
 		t.Fatal("Stack is nil")
+		return
 	}
 
 	for _, tag := range stack.Tags {
@@ -149,7 +153,7 @@ func AssertStackTag(t *testing.T, stack *types.Stack, key, expectedValue string)
 			}
 			t.Errorf("Tag %s value mismatch\nGot: %v\nExpected: %s",
 				key,
-				*tag.Value,
+				stringValueOrNil(tag.Value),
 				expectedValue)
 			return
 		}
@@ -164,6 +168,7 @@ func AssertChangesetStatus(t *testing.T, changeset *cloudformation.DescribeChang
 
 	if changeset == nil {
 		t.Fatal("Changeset is nil")
+		return
 	}
 
 	if changeset.Status != expectedStatus {
@@ -177,6 +182,7 @@ func AssertChangesetHasChanges(t *testing.T, changeset *cloudformation.DescribeC
 
 	if changeset == nil {
 		t.Fatal("Changeset is nil")
+		return
 	}
 
 	if len(changeset.Changes) == 0 {
@@ -190,6 +196,7 @@ func AssertChangesetNoChanges(t *testing.T, changeset *cloudformation.DescribeCh
 
 	if changeset == nil {
 		t.Fatal("Changeset is nil")
+		return
 	}
 
 	if len(changeset.Changes) > 0 {
@@ -309,6 +316,14 @@ func AssertNil(t *testing.T, value any, name string) {
 	if value != nil {
 		t.Errorf("%s should be nil but got: %v", name, value)
 	}
+}
+
+func stringValueOrNil(value *string) any {
+	if value == nil {
+		return "<nil>"
+	}
+
+	return *value
 }
 
 // Common cmp options for comparing AWS types

--- a/lib/testutil/assertions.go
+++ b/lib/testutil/assertions.go
@@ -318,7 +318,7 @@ func AssertNil(t *testing.T, value any, name string) {
 	}
 }
 
-func stringValueOrNil(value *string) any {
+func stringValueOrNil(value *string) string {
 	if value == nil {
 		return "<nil>"
 	}

--- a/lib/testutil/assertions_test.go
+++ b/lib/testutil/assertions_test.go
@@ -1,0 +1,110 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssertStackParameter_NilValue(t *testing.T) {
+	t.Parallel()
+
+	output := runAssertionFailureHelper(t, "parameter-nil-value")
+
+	assertAssertionFailure(t, output,
+		"Parameter Environment value mismatch",
+		"Got: <nil>",
+		"Expected: production",
+	)
+}
+
+func TestAssertStackOutput_NilValue(t *testing.T) {
+	t.Parallel()
+
+	output := runAssertionFailureHelper(t, "output-nil-value")
+
+	assertAssertionFailure(t, output,
+		"Output ServiceURL value mismatch",
+		"Got: <nil>",
+		"Expected: https://example.com",
+	)
+}
+
+func TestAssertStackTag_NilValue(t *testing.T) {
+	t.Parallel()
+
+	output := runAssertionFailureHelper(t, "tag-nil-value")
+
+	assertAssertionFailure(t, output,
+		"Tag Environment value mismatch",
+		"Got: <nil>",
+		"Expected: production",
+	)
+}
+
+func TestAssertionFailureHelper(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("FOG_ASSERTION_HELPER") != "1" {
+		t.Skip("helper process only")
+	}
+
+	switch os.Getenv("FOG_ASSERTION_SCENARIO") {
+	case "parameter-nil-value":
+		AssertStackParameter(t, &types.Stack{
+			Parameters: []types.Parameter{
+				{
+					ParameterKey: aws.String("Environment"),
+				},
+			},
+		}, "Environment", "production")
+	case "output-nil-value":
+		AssertStackOutput(t, &types.Stack{
+			Outputs: []types.Output{
+				{
+					OutputKey: aws.String("ServiceURL"),
+				},
+			},
+		}, "ServiceURL", "https://example.com")
+	case "tag-nil-value":
+		AssertStackTag(t, &types.Stack{
+			Tags: []types.Tag{
+				{
+					Key: aws.String("Environment"),
+				},
+			},
+		}, "Environment", "production")
+	default:
+		t.Fatalf("unknown helper scenario %q", os.Getenv("FOG_ASSERTION_SCENARIO"))
+	}
+}
+
+func runAssertionFailureHelper(t *testing.T, scenario string) string {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestAssertionFailureHelper$")
+	cmd.Env = append(os.Environ(),
+		"FOG_ASSERTION_HELPER=1",
+		"FOG_ASSERTION_SCENARIO="+scenario,
+	)
+
+	output, err := cmd.CombinedOutput()
+	require.Error(t, err, "expected helper assertion to fail")
+
+	return string(output)
+}
+
+func assertAssertionFailure(t *testing.T, output string, expectedParts ...string) {
+	t.Helper()
+
+	assert.NotContains(t, output, "panic:", "assertion helper should fail cleanly without panicking")
+
+	for _, expectedPart := range expectedParts {
+		assert.Contains(t, output, expectedPart)
+	}
+}

--- a/lib/testutil/assertions_test.go
+++ b/lib/testutil/assertions_test.go
@@ -48,10 +48,8 @@ func TestAssertStackTag_NilValue(t *testing.T) {
 }
 
 func TestAssertionFailureHelper(t *testing.T) {
-	t.Helper()
-
 	if os.Getenv("FOG_ASSERTION_HELPER") != "1" {
-		t.Skip("helper process only")
+		return
 	}
 
 	switch os.Getenv("FOG_ASSERTION_SCENARIO") {

--- a/specs/bugfixes/fix-nil-unsafe-test-assertions-blocking-lint/report.md
+++ b/specs/bugfixes/fix-nil-unsafe-test-assertions-blocking-lint/report.md
@@ -1,0 +1,79 @@
+# Bugfix Report: fix-nil-unsafe-test-assertions-blocking-lint
+
+**Date:** 2026-04-28
+**Status:** Fixed
+
+## Description of the Issue
+
+`lib/testutil/assertions.go` contains assertion helpers that call `t.Fatal(...)` for nil `stack` and `changeset` inputs but then continue into code that dereferences those values. The same file also dereferences optional AWS SDK `*string` fields in mismatch paths for stack parameters, outputs, and tags.
+
+**Reproduction steps:**
+1. Run `make lint` with repository-local cache directories.
+2. Inspect `lib/testutil/assertions.go` and exercise the assertion helpers with malformed AWS responses containing nil optional fields.
+3. Observe staticcheck SA5011 warnings and nil-pointer panics from the assertion helpers instead of clean test failures.
+
+**Impact:** Linting is blocked and malformed AWS test fixtures can panic inside assertion helpers, hiding the actual test failure.
+
+## Investigation Summary
+
+- **Symptoms examined:** SA5011 nil-dereference warnings and panic-prone mismatch code paths in assertion helpers.
+- **Code inspected:** `lib/testutil/assertions.go`, `Makefile`, `.golangci.yml`.
+- **Hypotheses tested:** Nil optional AWS SDK string fields reach mismatch branches; `t.Fatal(...)` alone is not enough to satisfy static analysis without an explicit return.
+
+## Discovered Root Cause
+
+The assertion helpers assumed optional AWS SDK `*string` fields were always non-nil when rendering mismatch messages, and they relied on `t.Fatal(...)` without explicit returns after nil guards.
+
+**Defect type:** Missing nil validation.
+
+**Why it occurred:** The helpers were written for happy-path test data, but AWS SDK v2 models use pointer fields for optional values and malformed fixtures can leave them nil.
+
+**Contributing factors:** The mismatch messages dereferenced pointer fields directly, and staticcheck treats code after `t.Fatal(...)` as reachable unless the function returns explicitly.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/testutil/assertions.go:55-199` — added explicit returns after fatal nil guards in stack and changeset helpers so static analysis no longer sees reachable dereferences.
+- `lib/testutil/assertions.go:104-107,129-132,154-157,321-327` — routed mismatch rendering through a nil-safe helper so malformed AWS SDK pointers show `<nil>` instead of panicking.
+- `lib/testutil/assertions_test.go:14-110` — added subprocess-based regression tests that prove nil parameter, output, and tag values fail cleanly without panics.
+
+**Approach rationale:** Keep the fix local to the assertion helpers. Explicit early returns address the lint warning directly, while a shared nil-safe formatter keeps mismatch messages readable without changing the helper APIs.
+
+**Alternatives considered:**
+- Broader assertion helper refactors — not chosen because the bug is isolated to a few nil-unsafe branches and does not require API changes.
+
+## Regression Test
+
+**Test file:** `lib/testutil/assertions_test.go`
+**Test names:**
+- `TestAssertStackParameter_NilValue`
+- `TestAssertStackOutput_NilValue`
+- `TestAssertStackTag_NilValue`
+
+**What it verifies:** Each helper reports a clean mismatch when the matching AWS SDK value pointer is nil, instead of panicking.
+
+**Run command:** `go test ./lib/testutil -run 'TestAssertStack(Parameter|Output|Tag)_NilValue' -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/testutil/assertions.go` | Added explicit returns after fatal nil checks and nil-safe mismatch formatting |
+| `lib/testutil/assertions_test.go` | Adds regression coverage for nil optional AWS SDK fields |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Treat AWS SDK pointer fields as nilable in both success and failure paths.
+- Return immediately after `t.Fatal(...)` in helpers when static analysis otherwise sees a reachable dereference path.
+
+## Related
+
+- Transit ticket: T-898


### PR DESCRIPTION
## Summary
- return immediately after fatal nil checks in test assertion helpers so staticcheck no longer reports reachable nil dereferences
- render `<nil>` safely in stack parameter/output/tag mismatch messages instead of dereferencing missing AWS SDK pointers
- add regression tests and a bugfix report at `specs/bugfixes/fix-nil-unsafe-test-assertions-blocking-lint/report.md`

## Root cause
The helpers assumed optional AWS SDK pointer fields were always populated and relied on `t.Fatal(...)` without explicit returns, which left both lint and malformed-fixture failure paths unsafe.

## Verification
- `go test ./lib/testutil -run 'TestAssertStack(Parameter|Output|Tag)_NilValue' -v`
- `go test ./... -v`
- `make lint`