### PR TITLE
Fix T-909: Make Test Assertion Helpers Nil-Safe

### DIFF
--- a/specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md
+++ b/specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md
@@ -1,0 +1,78 @@
+# Bugfix Report: Make test assertion helpers nil-safe
+
+**Date:** 2026-04-28
+**Status:** Investigating
+
+## Description of the Issue
+
+Several shared test assertion helpers in `lib/testutil/assertions.go` handled nil `stack` and `changeset` inputs with `t.Fatal(...)`, but did not make the terminating control flow explicit before later dereferences. The same file also printed mismatch messages by unconditionally dereferencing optional AWS string pointers such as `ParameterValue`, `OutputValue`, and `Tag.Value`.
+
+**Reproduction steps:**
+1. Call `AssertStackParameter`, `AssertStackOutput`, or `AssertStackTag` with a matching key and a nil optional value pointer.
+2. Let the helper hit the mismatch branch while building the failure message.
+3. Observe a panic instead of a useful assertion failure.
+
+**Impact:** Shared test helpers could panic during failure reporting, and static analysis flagged nil-dereference paths that should be guarded explicitly.
+
+## Investigation Summary
+
+Reviewed the assertion helpers in `lib/testutil/assertions.go` and compared the nil guards with the later pointer dereferences in the same functions. The optional value mismatch branches were directly reproducible as panic paths, while the nil-input guards needed explicit early returns to satisfy the intended control flow and keep the helpers obviously safe.
+
+- **Symptoms examined:** potential nil dereferences reported by static analysis and panic-prone mismatch reporting
+- **Code inspected:** `lib/testutil/assertions.go`
+- **Hypotheses tested:** nil optional AWS pointer values cause panic in mismatch formatting; nil `stack` / `changeset` guards should terminate helper execution explicitly
+
+## Discovered Root Cause
+
+The helpers mixed fatal assertion reporting with later pointer access without an explicit exit, and they formatted mismatch output by dereferencing optional AWS pointers without checking for nil first.
+
+**Defect type:** Missing validation / unsafe nil handling
+
+**Why it occurred:** The helpers assumed AWS optional string fields would always be populated when a matching key existed, and they relied on `t.Fatal` side effects instead of making the non-nil precondition explicit in code.
+
+**Contributing factors:** Shared helpers were not covered by focused regression tests for nil inputs and nil optional value fields.
+
+## Resolution for the Issue
+
+**Changes made:**
+
+**Approach rationale:** 
+
+**Alternatives considered:**
+- Change helper signatures to accept a broader testing interface - avoided to keep the exported API unchanged
+
+## Regression Test
+
+**Test file:** `lib/testutil/assertions_test.go`
+**Test name:** `TestAssertStackValueHelpers_DoNotPanicOnNilOptionalValues`
+
+**What it verifies:** Nil optional parameter, output, and tag values no longer panic during mismatch reporting, and nil stack / changeset guards stop helper execution correctly.
+
+**Run command:** `go test ./lib/testutil -run 'TestRequireStack|TestRequireChangeset|TestFormatOptionalString|TestAssertStackValueHelpers|TestAssertChangesetHelpers|TestAssertStackStatus'`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/testutil/assertions.go` | Will be updated to make nil handling explicit and safe |
+| `lib/testutil/assertions_test.go` | Adds regression coverage for nil inputs and nil optional pointer values |
+
+## Verification
+
+**Automated:**
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+**Manual verification:**
+- Not applicable
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Add focused tests for helper failure paths, especially when optional AWS pointers are involved
+- Prefer dedicated nil-safe formatting helpers when building assertion messages from optional pointer fields
+
+## Related
+
+- Transit ticket `T-909`

--- a/specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md
+++ b/specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md
@@ -1,7 +1,7 @@
 # Bugfix Report: Make test assertion helpers nil-safe
 
 **Date:** 2026-04-28
-**Status:** Investigating
+**Status:** Fixed
 
 ## Description of the Issue
 
@@ -35,8 +35,10 @@ The helpers mixed fatal assertion reporting with later pointer access without an
 ## Resolution for the Issue
 
 **Changes made:**
+- `lib/testutil/assertions.go` - added shared nil guards for stacks and changesets, returned immediately after fatal assertions, and routed mismatch output through nil-safe optional string formatting helpers
+- `lib/testutil/assertions_test.go` - added regression tests for nil stack/changeset guard helpers and nil optional AWS pointer formatting
 
-**Approach rationale:** 
+**Approach rationale:** Extracting the nil guards and mismatch formatting into small helper functions made the intended control flow explicit, satisfied static analysis, and gave the package direct regression coverage for the previously unsafe paths.
 
 **Alternatives considered:**
 - Change helper signatures to accept a broader testing interface - avoided to keep the exported API unchanged
@@ -44,25 +46,26 @@ The helpers mixed fatal assertion reporting with later pointer access without an
 ## Regression Test
 
 **Test file:** `lib/testutil/assertions_test.go`
-**Test name:** `TestAssertStackValueHelpers_DoNotPanicOnNilOptionalValues`
+**Test name:** `TestRequireStack_ReturnsFalseAfterFatalOnNil`, `TestRequireChangeset_ReturnsFalseAfterFatalOnNil`, `TestFormatOptionalString`, `TestFormatValueMismatch`
 
-**What it verifies:** Nil optional parameter, output, and tag values no longer panic during mismatch reporting, and nil stack / changeset guards stop helper execution correctly.
+**What it verifies:** Nil stack and changeset guards return immediately after recording a fatal assertion, and mismatch message formatting stays safe when AWS optional string pointers are nil.
 
-**Run command:** `go test ./lib/testutil -run 'TestRequireStack|TestRequireChangeset|TestFormatOptionalString|TestAssertStackValueHelpers|TestAssertChangesetHelpers|TestAssertStackStatus'`
+**Run command:** `go test ./lib/testutil -run 'TestRequireStack|TestRequireChangeset|TestFormatOptionalString|TestFormatValueMismatch'`
 
 ## Affected Files
 
 | File | Change |
 |------|--------|
-| `lib/testutil/assertions.go` | Will be updated to make nil handling explicit and safe |
-| `lib/testutil/assertions_test.go` | Adds regression coverage for nil inputs and nil optional pointer values |
+| `lib/testutil/assertions.go` | Makes nil preconditions explicit and formats optional AWS strings safely in mismatch paths |
+| `lib/testutil/assertions_test.go` | Adds regression coverage for nil guard helpers and nil-safe mismatch formatting |
+| `specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md` | Documents investigation, root cause, fix, and verification |
 
 ## Verification
 
 **Automated:**
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
 
 **Manual verification:**
 - Not applicable

--- a/specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md
+++ b/specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md
@@ -46,11 +46,11 @@ The helpers mixed fatal assertion reporting with later pointer access without an
 ## Regression Test
 
 **Test file:** `lib/testutil/assertions_test.go`
-**Test name:** `TestRequireStack_ReturnsFalseAfterFatalOnNil`, `TestRequireChangeset_ReturnsFalseAfterFatalOnNil`, `TestFormatOptionalString`, `TestFormatValueMismatch`
+**Test name:** `TestRequireStack_ReturnsFalseAfterFatalOnNil`, `TestRequireChangeset_ReturnsFalseAfterFatalOnNil`, `TestFormatOptionalString`, `TestFormatValueMismatch`, `TestAssertStackHelpers_NilValueMismatchDoesNotPanic`
 
-**What it verifies:** Nil stack and changeset guards return immediately after recording a fatal assertion, and mismatch message formatting stays safe when AWS optional string pointers are nil.
+**What it verifies:** Nil stack and changeset guards return immediately after recording a fatal assertion, mismatch message formatting stays safe when AWS optional string pointers are nil, and stack assertion helpers do not panic when a matching key has a nil optional value pointer during mismatch reporting.
 
-**Run command:** `go test ./lib/testutil -run 'TestRequireStack|TestRequireChangeset|TestFormatOptionalString|TestFormatValueMismatch'`
+**Run command:** `go test ./lib/testutil -run 'TestRequireStack|TestRequireChangeset|TestFormatOptionalString|TestFormatValueMismatch|TestAssertStackHelpers_NilValueMismatchDoesNotPanic'`
 
 ## Affected Files
 


### PR DESCRIPTION
## Summary
- return immediately after fatal nil stack and changeset guards in shared test assertion helpers
- format optional AWS parameter, output, and tag values safely in mismatch messages instead of dereferencing nil pointers
- add regression coverage and a bugfix report for T-909

## Root cause
The helpers relied on `t.Fatal(...)` without making the non-nil precondition explicit in code, and mismatch reporting dereferenced optional AWS string pointers even when they were nil.

## Verification
- `go test ./lib/testutil -run 'TestRequireStack|TestRequireChangeset|TestFormatOptionalString|TestFormatValueMismatch'`
- `go test ./... -v`
- `make lint`

## Documentation
- `specs/bugfixes/make-test-assertion-helpers-nil-safe/report.md`
