### PR TITLE
Fix T-1014: Route CLI Command Errors to Stderr

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -64,7 +64,7 @@ func addToField(field *map[string]any, key string, value int) {
 }
 
 func failWithError(err error) {
-	fmt.Print(output.StyleNegative(fmt.Sprintf("Error: %v", err)))
+	fmt.Fprint(os.Stderr, output.StyleNegative(fmt.Sprintf("Error: %v", err)))
 	if viper.GetBool("debug") {
 		panic(err)
 	}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestFailWithError_WritesToStderr is a regression test for T-1014.
+// Errors routed through failWithError must stay off stdout so structured output
+// pipelines only receive command results on stdout.
+func TestFailWithError_WritesToStderr(t *testing.T) {
+	if os.Getenv("GO_WANT_FAIL_WITH_ERROR_HELPER") == "1" {
+		failWithError(errors.New("boom"))
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestFailWithError_WritesToStderr")
+	cmd.Env = append(os.Environ(), "GO_WANT_FAIL_WITH_ERROR_HELPER=1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected subprocess to exit with an error, got %v", err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitErr.ExitCode())
+	}
+
+	if got := stdout.String(); got != "" {
+		t.Fatalf("expected no stdout output, got %q", got)
+	}
+	if got := stderr.String(); got == "" {
+		t.Fatal("expected error output on stderr, got nothing")
+	}
+	if got := stderr.String(); !bytes.Contains([]byte(got), []byte("Error: boom")) {
+		t.Fatalf("expected stderr to contain error message, got %q", got)
+	}
+}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -13,6 +13,8 @@ import (
 // stderr so structured stdout pipelines only receive command results.
 func TestFailWithError_WritesToStderr(t *testing.T) {
 	if os.Getenv("GO_WANT_FAIL_WITH_ERROR_HELPER") == "1" {
+		// The subprocess uses the default debug=false setting, so failWithError
+		// exits and lets the parent process assert stderr/stdout behavior.
 		failWithError(errors.New("boom"))
 		return
 	}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -17,7 +17,7 @@ func TestFailWithError_WritesToStderr(t *testing.T) {
 		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestFailWithError_WritesToStderr")
+	cmd := exec.Command(os.Args[0], "-test.run=^TestFailWithError_WritesToStderr$")
 	cmd.Env = append(os.Environ(), "GO_WANT_FAIL_WITH_ERROR_HELPER=1")
 
 	var stdout bytes.Buffer
@@ -37,10 +37,11 @@ func TestFailWithError_WritesToStderr(t *testing.T) {
 	if got := stdout.String(); got != "" {
 		t.Fatalf("expected no stdout output, got %q", got)
 	}
-	if got := stderr.String(); got == "" {
+	got := stderr.String()
+	if got == "" {
 		t.Fatal("expected error output on stderr, got nothing")
 	}
-	if got := stderr.String(); !bytes.Contains([]byte(got), []byte("Error: boom")) {
+	if !bytes.Contains([]byte(got), []byte("Error: boom")) {
 		t.Fatalf("expected stderr to contain error message, got %q", got)
 	}
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
-// TestFailWithError_WritesToStderr is a regression test for T-1014.
-// Errors routed through failWithError must stay off stdout so structured output
-// pipelines only receive command results on stdout.
+// TestFailWithError_WritesToStderr verifies failWithError keeps diagnostics on
+// stderr so structured stdout pipelines only receive command results.
 func TestFailWithError_WritesToStderr(t *testing.T) {
 	if os.Getenv("GO_WANT_FAIL_WITH_ERROR_HELPER") == "1" {
 		failWithError(errors.New("boom"))
@@ -41,7 +41,7 @@ func TestFailWithError_WritesToStderr(t *testing.T) {
 	if got == "" {
 		t.Fatal("expected error output on stderr, got nothing")
 	}
-	if !bytes.Contains([]byte(got), []byte("Error: boom")) {
+	if !strings.Contains(got, "Error: boom") {
 		t.Fatalf("expected stderr to contain error message, got %q", got)
 	}
 }

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -9,11 +9,22 @@ import (
 	"testing"
 )
 
-func envWithout(key string) []string {
-	prefix := key + "="
+func envWithout(keys ...string) []string {
+	prefixes := make([]string, 0, len(keys))
+	for _, key := range keys {
+		prefixes = append(prefixes, key+"=")
+	}
+
 	filtered := make([]string, 0, len(os.Environ()))
 	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, prefix) {
+		skip := false
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(env, prefix) {
+				skip = true
+				break
+			}
+		}
+		if skip {
 			continue
 		}
 		filtered = append(filtered, env)
@@ -24,15 +35,23 @@ func envWithout(key string) []string {
 // TestFailWithError_WritesToStderr verifies failWithError keeps diagnostics on
 // stderr so structured stdout pipelines only receive command results.
 func TestFailWithError_WritesToStderr(t *testing.T) {
-	if os.Getenv("GO_WANT_FAIL_WITH_ERROR_HELPER") == "1" {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") == "1" && os.Getenv("GO_WANT_FAIL_WITH_ERROR_HELPER") == "1" {
 		// The subprocess uses the default debug=false setting, so failWithError
 		// exits and lets the parent process assert stderr/stdout behavior.
 		failWithError(errors.New("boom"))
 		return
 	}
 
+	t.Setenv("GO_WANT_HELPER_PROCESS", "")
+	t.Setenv("GO_WANT_FAIL_WITH_ERROR_HELPER", "")
+
 	cmd := exec.Command(os.Args[0], "-test.run=^TestFailWithError_WritesToStderr$")
-	cmd.Env = append(envWithout("DEBUG"), "GO_WANT_FAIL_WITH_ERROR_HELPER=1", "DEBUG=false")
+	cmd.Env = append(
+		envWithout("DEBUG", "GO_WANT_HELPER_PROCESS", "GO_WANT_FAIL_WITH_ERROR_HELPER"),
+		"GO_WANT_HELPER_PROCESS=1",
+		"GO_WANT_FAIL_WITH_ERROR_HELPER=1",
+		"DEBUG=false",
+	)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -9,6 +9,18 @@ import (
 	"testing"
 )
 
+func envWithout(key string) []string {
+	prefix := key + "="
+	filtered := make([]string, 0, len(os.Environ()))
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, prefix) {
+			continue
+		}
+		filtered = append(filtered, env)
+	}
+	return filtered
+}
+
 // TestFailWithError_WritesToStderr verifies failWithError keeps diagnostics on
 // stderr so structured stdout pipelines only receive command results.
 func TestFailWithError_WritesToStderr(t *testing.T) {
@@ -20,7 +32,7 @@ func TestFailWithError_WritesToStderr(t *testing.T) {
 	}
 
 	cmd := exec.Command(os.Args[0], "-test.run=^TestFailWithError_WritesToStderr$")
-	cmd.Env = append(os.Environ(), "GO_WANT_FAIL_WITH_ERROR_HELPER=1")
+	cmd.Env = append(envWithout("DEBUG"), "GO_WANT_FAIL_WITH_ERROR_HELPER=1", "DEBUG=false")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/specs/bugfixes/route-cli-command-errors-to-stderr/report.md
+++ b/specs/bugfixes/route-cli-command-errors-to-stderr/report.md
@@ -1,0 +1,71 @@
+# Bugfix Report: Route CLI command errors to stderr
+
+**Date:** 2026-04-28
+**Status:** Fixed
+
+## Description of the Issue
+
+CLI commands that fail through `failWithError` wrote diagnostics to stdout instead of stderr. That polluted structured stdout output such as JSON, CSV, or YAML and broke shell pipelines that expected stdout to contain only command results.
+
+**Reproduction steps:**
+1. Run a command that reaches `failWithError`, such as `fog drift --output json` with invalid inputs.
+2. Trigger a command error.
+3. Observe the error text emitted on stdout instead of stderr.
+
+**Impact:** Structured CLI output became unreliable for failing commands that use `failWithError`, affecting automation and shell pipelines.
+
+## Investigation Summary
+
+The investigation focused on the shared command failure path and the existing stdout/stderr separation tests in the `cmd` package.
+
+- **Symptoms examined:** Structured command output was contaminated by fatal error messages.
+- **Code inspected:** `cmd/helpers.go`, `cmd/stream_separation_test.go`, and commands that call `failWithError`.
+- **Hypotheses tested:** Whether the incorrect stream routing came from command-specific output builders or the shared fatal helper. Inspection confirmed the shared helper was writing directly with `fmt.Print`, which targets stdout.
+
+## Discovered Root Cause
+
+`failWithError` used `fmt.Print(output.StyleNegative(...))`, so every command path that called the helper wrote user-facing errors to stdout before exiting.
+
+**Defect type:** Incorrect output stream selection
+
+**Why it occurred:** The shared helper printed a formatted error message without directing it to `os.Stderr`, and there was no regression test covering the exiting error path.
+
+**Contributing factors:** Multiple commands reused the helper, which amplified the impact of the incorrect default stream.
+
+## Resolution for the Issue
+
+## Regression Test
+
+**Test file:** `cmd/helpers_test.go`
+**Test name:** `TestFailWithError_WritesToStderr`
+
+**What it verifies:** The shared fatal error helper exits with status 1, leaves stdout empty, and writes the error message to stderr.
+
+**Run command:** `go test ./cmd -run TestFailWithError_WritesToStderr`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/helpers.go` | Shared fatal error helper for several CLI commands |
+| `cmd/helpers_test.go` | Regression test for fatal error stream routing |
+
+## Verification
+
+**Automated:**
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+**Manual verification:**
+- Reviewed the shared error helper and confirmed the bug reproduces through any command that calls it.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Add regression tests around shared stdout/stderr routing for command exit paths.
+- Prefer explicit writers (`os.Stdout` / `os.Stderr`) in shared CLI helpers.
+
+## Related
+
+- Transit ticket `T-1014`

--- a/specs/bugfixes/route-cli-command-errors-to-stderr/report.md
+++ b/specs/bugfixes/route-cli-command-errors-to-stderr/report.md
@@ -34,6 +34,15 @@ The investigation focused on the shared command failure path and the existing st
 
 ## Resolution for the Issue
 
+**Changes made:**
+- `cmd/helpers.go:66` - Changed `failWithError` to write formatted error output to `os.Stderr` before exiting.
+- `cmd/helpers_test.go:1` - Added a regression test that executes the fatal helper in a subprocess and asserts stderr-only diagnostics.
+
+**Approach rationale:** The bug came from a single shared helper using the wrong stream, so the safest fix was to correct that helper directly and lock the behavior in with a regression test.
+
+**Alternatives considered:**
+- Refactor commands to return errors instead of exiting from `failWithError` - not chosen because it would touch many call sites for a bug caused by one incorrect writer.
+
 ## Regression Test
 
 **Test file:** `cmd/helpers_test.go`
@@ -53,12 +62,13 @@ The investigation focused on the shared command failure path and the existing st
 ## Verification
 
 **Automated:**
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
 
 **Manual verification:**
-- Reviewed the shared error helper and confirmed the bug reproduces through any command that calls it.
+- Confirmed the regression test failed before the fix because the error text was emitted on stdout.
+- Reviewed the shared helper after the change to verify the error path now targets stderr directly.
 
 ## Prevention
 


### PR DESCRIPTION
## Summary
- route fatal CLI diagnostics through stderr in failWithError
- add a regression test covering the exiting error path
- document the investigation and fix in specs/bugfixes/route-cli-command-errors-to-stderr/report.md

## Root cause
failWithError printed its formatted error message with fmt.Print, which writes to stdout and contaminated structured command output.

## Verification
- go test ./cmd -run TestFailWithError_WritesToStderr
- go test ./... -v
- golangci-lint run
- go build -o fog