### PR TITLE
Fix T-1015: Drift Structured Error Handling

### DIFF
--- a/cmd/deploy_helpers.go
+++ b/cmd/deploy_helpers.go
@@ -32,9 +32,6 @@ var askForConfirmationFunc = askForConfirmation
 var showFailedEventsFunc = showFailedEvents
 var deleteStackIfNewFunc = deleteStackIfNew
 
-// osExitFunc allows tests to intercept os.Exit calls in command handlers.
-var osExitFunc = os.Exit
-
 const postDeployLookupFailedStatus = "POST_DEPLOY_LOOKUP_FAILED"
 
 var getFreshStackFunc = func(info *lib.DeployInfo, svc lib.CloudFormationDescribeStacksAPI) (types.Stack, error) {

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -44,11 +44,7 @@ import (
 
 var driftFlags DriftFlags
 
-type listAllResourcesFunc func(ctx context.Context, typeName string, cloudControlClient lib.CloudControlListResourcesAPI, ssoClient interface {
-	lib.SSOAdminListInstancesAPI
-	lib.SSOAdminListPermissionSetsAPI
-	lib.SSOAdminListAccountAssignmentsAPI
-}, organizationsClient lib.OrganizationsListAccountsAPI) (map[string]string, error)
+type listAllResourcesFunc func(ctx context.Context, typeName string, cloudControlClient lib.CloudControlListResourcesAPI, ssoClient lib.SSOAdminClient, organizationsClient lib.OrganizationsListAccountsAPI) (map[string]string, error)
 
 // driftCmd represents the drift command
 var driftCmd = &cobra.Command{

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -253,7 +253,7 @@ func separateSpecialCases(ctx context.Context, defaultDrift []types.StackResourc
 		StackName: stackName,
 	})
 	if err != nil {
-		return naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical, fmt.Errorf("failed to describe stack resources for drift special cases: %w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to describe stack resources for drift special cases: %w", err)
 	}
 	for _, resource := range stackResourcesResp.StackResources {
 		if resource.LogicalResourceId == nil || resource.PhysicalResourceId == nil {
@@ -298,6 +298,8 @@ func separateSpecialCases(ctx context.Context, defaultDrift []types.StackResourc
 }
 
 func detectUnmanagedResources(ctx context.Context, resourceTypes []string, logicalToPhysical map[string]string, rows *[]map[string]any, awsConfig config.AWSConfig, listResources listAllResourcesFunc) error {
+	// Stop on the first lookup error so the command doesn't mix incomplete
+	// unmanaged-resource data with successful results from other resource types.
 	for _, resourceType := range resourceTypes {
 		allResources, err := listResources(ctx, resourceType, awsConfig.CloudControlClient(), awsConfig.SSOAdminClient(), awsConfig.OrganizationsClient())
 		if err != nil {

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -43,7 +43,12 @@ import (
 )
 
 var driftFlags DriftFlags
-var listAllResourcesFunc = lib.ListAllResources
+
+type listAllResourcesFunc func(ctx context.Context, typeName string, cloudControlClient lib.CloudControlListResourcesAPI, ssoClient interface {
+	lib.SSOAdminListInstancesAPI
+	lib.SSOAdminListPermissionSetsAPI
+	lib.SSOAdminListAccountAssignmentsAPI
+}, organizationsClient lib.OrganizationsListAccountsAPI) (map[string]string, error)
 
 // driftCmd represents the drift command
 var driftCmd = &cobra.Command{
@@ -201,7 +206,7 @@ func detectDrift(cmd *cobra.Command, args []string) {
 	checkNaclEntries(ctx, naclResources, template, stack.Parameters, logicalToPhysical, &rows, awsConfig)
 	checkRouteTableRoutes(ctx, routetableResources, template, stack.Parameters, logicalToPhysical, &rows, awsConfig)
 	checkTransitGatewayRouteTableRoutes(ctx, tgwRouteTableResources, template, stack.Parameters, logicalToPhysical, &rows, awsConfig)
-	if err := detectUnmanagedResources(ctx, settings.GetStringSlice("drift.detect-unmanaged-resources"), logicalToPhysical, &rows, awsConfig); err != nil {
+	if err := detectUnmanagedResources(ctx, settings.GetStringSlice("drift.detect-unmanaged-resources"), logicalToPhysical, &rows, awsConfig, lib.ListAllResources); err != nil {
 		failWithError(err)
 	}
 
@@ -296,13 +301,13 @@ func separateSpecialCases(ctx context.Context, defaultDrift []types.StackResourc
 	return naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical, nil
 }
 
-func detectUnmanagedResources(ctx context.Context, resourceTypes []string, logicalToPhysical map[string]string, rows *[]map[string]any, awsConfig config.AWSConfig) error {
+func detectUnmanagedResources(ctx context.Context, resourceTypes []string, logicalToPhysical map[string]string, rows *[]map[string]any, awsConfig config.AWSConfig, listResources listAllResourcesFunc) error {
 	for _, resourceType := range resourceTypes {
-		allresources, err := listAllResourcesFunc(ctx, resourceType, awsConfig.CloudControlClient(), awsConfig.SSOAdminClient(), awsConfig.OrganizationsClient())
+		allResources, err := listResources(ctx, resourceType, awsConfig.CloudControlClient(), awsConfig.SSOAdminClient(), awsConfig.OrganizationsClient())
 		if err != nil {
 			return fmt.Errorf("failed to list unmanaged resources for %s: %w", resourceType, err)
 		}
-		checkIfResourcesAreManaged(allresources, logicalToPhysical, rows)
+		checkIfResourcesAreManaged(allResources, logicalToPhysical, rows)
 	}
 	return nil
 }

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -300,8 +300,12 @@ func separateSpecialCases(ctx context.Context, defaultDrift []types.StackResourc
 func detectUnmanagedResources(ctx context.Context, resourceTypes []string, logicalToPhysical map[string]string, rows *[]map[string]any, awsConfig config.AWSConfig, listResources listAllResourcesFunc) error {
 	// Stop on the first lookup error so the command doesn't mix incomplete
 	// unmanaged-resource data with successful results from other resource types.
+	cloudControlClient := awsConfig.CloudControlClient()
+	ssoClient := awsConfig.SSOAdminClient()
+	organizationsClient := awsConfig.OrganizationsClient()
+
 	for _, resourceType := range resourceTypes {
-		allResources, err := listResources(ctx, resourceType, awsConfig.CloudControlClient(), awsConfig.SSOAdminClient(), awsConfig.OrganizationsClient())
+		allResources, err := listResources(ctx, resourceType, cloudControlClient, ssoClient, organizationsClient)
 		if err != nil {
 			return fmt.Errorf("failed to list unmanaged resources for %s: %w", resourceType, err)
 		}

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -43,6 +43,7 @@ import (
 )
 
 var driftFlags DriftFlags
+var listAllResourcesFunc = lib.ListAllResources
 
 // driftCmd represents the drift command
 var driftCmd = &cobra.Command{
@@ -99,7 +100,10 @@ func detectDrift(cmd *cobra.Command, args []string) {
 	if err != nil {
 		failWithError(err)
 	}
-	naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical := separateSpecialCases(ctx, defaultDrift, &driftFlags.StackName, svc)
+	naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical, err := separateSpecialCases(ctx, defaultDrift, &driftFlags.StackName, svc)
+	if err != nil {
+		failWithError(err)
+	}
 	// Build rows incrementally
 	rows := make([]map[string]any, 0)
 
@@ -197,12 +201,8 @@ func detectDrift(cmd *cobra.Command, args []string) {
 	checkNaclEntries(ctx, naclResources, template, stack.Parameters, logicalToPhysical, &rows, awsConfig)
 	checkRouteTableRoutes(ctx, routetableResources, template, stack.Parameters, logicalToPhysical, &rows, awsConfig)
 	checkTransitGatewayRouteTableRoutes(ctx, tgwRouteTableResources, template, stack.Parameters, logicalToPhysical, &rows, awsConfig)
-	for _, resourcetype := range settings.GetStringSlice("drift.detect-unmanaged-resources") {
-		allresources, err := lib.ListAllResources(ctx, resourcetype, awsConfig.CloudControlClient(), awsConfig.SSOAdminClient(), awsConfig.OrganizationsClient())
-		if err != nil {
-			log.Fatal(err)
-		}
-		checkIfResourcesAreManaged(allresources, logicalToPhysical, &rows)
+	if err := detectUnmanagedResources(ctx, settings.GetStringSlice("drift.detect-unmanaged-resources"), logicalToPhysical, &rows, awsConfig); err != nil {
+		failWithError(err)
 	}
 
 	// Create and render the document
@@ -240,7 +240,7 @@ func driftHasRequiredFields(drift types.StackResourceDrift) bool {
 func separateSpecialCases(ctx context.Context, defaultDrift []types.StackResourceDrift, stackName *string, svc interface {
 	lib.CloudFormationDescribeStackResourcesAPI
 	lib.CloudFormationListExportsAPI
-}) (map[string]string, map[string]string, map[string]string, map[string]string) {
+}) (map[string]string, map[string]string, map[string]string, map[string]string, error) {
 	naclResources := make(map[string]string)
 	routetableResources := make(map[string]string)
 	tgwRouteTableResources := make(map[string]string)
@@ -252,7 +252,7 @@ func separateSpecialCases(ctx context.Context, defaultDrift []types.StackResourc
 		StackName: stackName,
 	})
 	if err != nil {
-		log.Fatal(err)
+		return naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical, fmt.Errorf("failed to describe stack resources for drift special cases: %w", err)
 	}
 	for _, resource := range stackResourcesResp.StackResources {
 		if resource.LogicalResourceId == nil || resource.PhysicalResourceId == nil {
@@ -293,7 +293,18 @@ func separateSpecialCases(ctx context.Context, defaultDrift []types.StackResourc
 			tgwRouteTableResources[*drift.LogicalResourceId] = *drift.PhysicalResourceId
 		}
 	}
-	return naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical
+	return naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical, nil
+}
+
+func detectUnmanagedResources(ctx context.Context, resourceTypes []string, logicalToPhysical map[string]string, rows *[]map[string]any, awsConfig config.AWSConfig) error {
+	for _, resourceType := range resourceTypes {
+		allresources, err := listAllResourcesFunc(ctx, resourceType, awsConfig.CloudControlClient(), awsConfig.SSOAdminClient(), awsConfig.OrganizationsClient())
+		if err != nil {
+			return fmt.Errorf("failed to list unmanaged resources for %s: %w", resourceType, err)
+		}
+		checkIfResourcesAreManaged(allresources, logicalToPhysical, rows)
+	}
+	return nil
 }
 
 func checkIfResourcesAreManaged(allresources map[string]string, logicalToPhysical map[string]string, rows *[]map[string]any) {

--- a/cmd/drift_specialcases_test.go
+++ b/cmd/drift_specialcases_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,16 +12,21 @@ import (
 
 type mockSpecialCasesClient struct {
 	describeStackResourcesOutput cloudformation.DescribeStackResourcesOutput
+	describeStackResourcesErr    error
 	listExportsOutput            cloudformation.ListExportsOutput
+	listExportsErr               error
 	// listExportsPages supports multi-page responses keyed by NextToken ("" = first page).
 	listExportsPages map[string]cloudformation.ListExportsOutput
 }
 
 func (m *mockSpecialCasesClient) DescribeStackResources(ctx context.Context, params *cloudformation.DescribeStackResourcesInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStackResourcesOutput, error) {
-	return &m.describeStackResourcesOutput, nil
+	return &m.describeStackResourcesOutput, m.describeStackResourcesErr
 }
 
 func (m *mockSpecialCasesClient) ListExports(ctx context.Context, params *cloudformation.ListExportsInput, optFns ...func(*cloudformation.Options)) (*cloudformation.ListExportsOutput, error) {
+	if m.listExportsErr != nil {
+		return nil, m.listExportsErr
+	}
 	if m.listExportsPages != nil {
 		token := ""
 		if params.NextToken != nil {
@@ -75,7 +81,10 @@ func TestSeparateSpecialCasesSkipsNilPhysicalResourceID(t *testing.T) {
 		},
 	}
 
-	naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical := separateSpecialCases(context.Background(), defaultDrift, &stackName, mock)
+	naclResources, routetableResources, tgwRouteTableResources, logicalToPhysical, err := separateSpecialCases(context.Background(), defaultDrift, &stackName, mock)
+	if err != nil {
+		t.Fatalf("separateSpecialCases() returned unexpected error: %v", err)
+	}
 
 	if got := logicalToPhysical["SubnetResource"]; got != "subnet-123" {
 		t.Fatalf("expected SubnetResource to map to subnet-123, got %q", got)
@@ -130,7 +139,10 @@ func TestSeparateSpecialCasesPaginatesListExports(t *testing.T) {
 		},
 	}
 
-	_, _, _, logicalToPhysical := separateSpecialCases(context.Background(), nil, &stackName, mock)
+	_, _, _, logicalToPhysical, err := separateSpecialCases(context.Background(), nil, &stackName, mock)
+	if err != nil {
+		t.Fatalf("separateSpecialCases() returned unexpected error: %v", err)
+	}
 
 	for _, tc := range []struct {
 		key  string
@@ -146,5 +158,19 @@ func TestSeparateSpecialCasesPaginatesListExports(t *testing.T) {
 		} else if got != tc.want {
 			t.Errorf("expected %s=%q, got %q", tc.key, tc.want, got)
 		}
+	}
+}
+
+func TestSeparateSpecialCasesReturnsDescribeStackResourcesError(t *testing.T) {
+	stackName := "test-stack"
+	expectedErr := errors.New("describe stack resources failed")
+
+	mock := &mockSpecialCasesClient{
+		describeStackResourcesErr: expectedErr,
+	}
+
+	_, _, _, _, err := separateSpecialCases(context.Background(), nil, &stackName, mock)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
 	}
 }

--- a/cmd/drift_specialcases_test.go
+++ b/cmd/drift_specialcases_test.go
@@ -14,7 +14,6 @@ type mockSpecialCasesClient struct {
 	describeStackResourcesOutput cloudformation.DescribeStackResourcesOutput
 	describeStackResourcesErr    error
 	listExportsOutput            cloudformation.ListExportsOutput
-	listExportsErr               error
 	// listExportsPages supports multi-page responses keyed by NextToken ("" = first page).
 	listExportsPages map[string]cloudformation.ListExportsOutput
 }
@@ -24,9 +23,6 @@ func (m *mockSpecialCasesClient) DescribeStackResources(ctx context.Context, par
 }
 
 func (m *mockSpecialCasesClient) ListExports(ctx context.Context, params *cloudformation.ListExportsInput, optFns ...func(*cloudformation.Options)) (*cloudformation.ListExportsOutput, error) {
-	if m.listExportsErr != nil {
-		return nil, m.listExportsErr
-	}
 	if m.listExportsPages != nil {
 		token := ""
 		if params.NextToken != nil {

--- a/cmd/drift_unmanaged_test.go
+++ b/cmd/drift_unmanaged_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/ArjenSchwarz/fog/config"
+	"github.com/ArjenSchwarz/fog/lib"
 	"github.com/spf13/viper"
 )
 
@@ -145,5 +149,30 @@ func TestCheckIfResourcesAreManaged_EmptyInputs(t *testing.T) {
 	checkIfResourcesAreManaged(allresources, map[string]string{}, &rows)
 	if len(rows) != 1 {
 		t.Fatalf("expected 1 unmanaged row with empty logicalToPhysical, got %d", len(rows))
+	}
+}
+
+func TestDetectUnmanagedResourcesReturnsListAllResourcesError(t *testing.T) {
+	expectedErr := errors.New("list all resources failed")
+
+	originalListAllResources := listAllResourcesFunc
+	listAllResourcesFunc = func(context.Context, string, lib.CloudControlListResourcesAPI, interface {
+		lib.SSOAdminListInstancesAPI
+		lib.SSOAdminListPermissionSetsAPI
+		lib.SSOAdminListAccountAssignmentsAPI
+	}, lib.OrganizationsListAccountsAPI) (map[string]string, error) {
+		return nil, expectedErr
+	}
+	t.Cleanup(func() {
+		listAllResourcesFunc = originalListAllResources
+	})
+
+	var rows []map[string]any
+	err := detectUnmanagedResources(context.Background(), []string{"AWS::S3::Bucket"}, map[string]string{}, &rows, config.AWSConfig{})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected error %v, got %v", expectedErr, err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected no rows when list fails, got %d", len(rows))
 	}
 }

--- a/cmd/drift_unmanaged_test.go
+++ b/cmd/drift_unmanaged_test.go
@@ -155,20 +155,16 @@ func TestCheckIfResourcesAreManaged_EmptyInputs(t *testing.T) {
 func TestDetectUnmanagedResourcesReturnsListAllResourcesError(t *testing.T) {
 	expectedErr := errors.New("list all resources failed")
 
-	originalListAllResources := listAllResourcesFunc
-	listAllResourcesFunc = func(context.Context, string, lib.CloudControlListResourcesAPI, interface {
+	listResources := func(context.Context, string, lib.CloudControlListResourcesAPI, interface {
 		lib.SSOAdminListInstancesAPI
 		lib.SSOAdminListPermissionSetsAPI
 		lib.SSOAdminListAccountAssignmentsAPI
 	}, lib.OrganizationsListAccountsAPI) (map[string]string, error) {
 		return nil, expectedErr
 	}
-	t.Cleanup(func() {
-		listAllResourcesFunc = originalListAllResources
-	})
 
 	var rows []map[string]any
-	err := detectUnmanagedResources(context.Background(), []string{"AWS::S3::Bucket"}, map[string]string{}, &rows, config.AWSConfig{})
+	err := detectUnmanagedResources(context.Background(), []string{"AWS::S3::Bucket"}, map[string]string{}, &rows, config.AWSConfig{}, listResources)
 	if !errors.Is(err, expectedErr) {
 		t.Fatalf("expected error %v, got %v", expectedErr, err)
 	}

--- a/cmd/drift_unmanaged_test.go
+++ b/cmd/drift_unmanaged_test.go
@@ -155,11 +155,7 @@ func TestCheckIfResourcesAreManaged_EmptyInputs(t *testing.T) {
 func TestDetectUnmanagedResourcesReturnsListAllResourcesError(t *testing.T) {
 	expectedErr := errors.New("list all resources failed")
 
-	listResources := func(context.Context, string, lib.CloudControlListResourcesAPI, interface {
-		lib.SSOAdminListInstancesAPI
-		lib.SSOAdminListPermissionSetsAPI
-		lib.SSOAdminListAccountAssignmentsAPI
-	}, lib.OrganizationsListAccountsAPI) (map[string]string, error) {
+	listResources := func(context.Context, string, lib.CloudControlListResourcesAPI, lib.SSOAdminClient, lib.OrganizationsListAccountsAPI) (map[string]string, error) {
 		return nil, expectedErr
 	}
 

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -68,5 +68,5 @@ func failWithError(err error) {
 	if viper.GetBool("debug") {
 		panic(err)
 	}
-	os.Exit(1)
+	osExitFunc(1)
 }

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -12,6 +12,9 @@ import (
 	"github.com/spf13/viper"
 )
 
+// osExitFunc allows tests to intercept os.Exit calls in command handlers.
+var osExitFunc = os.Exit
+
 // askForConfirmation asks the user for confirmation. A user must type in "yes" or "no" and
 // then press enter. It has fuzzy matching, so "y", "Y", "yes", "YES", and "Yes" all count as
 // confirmations. If the input is not recognized, it will ask again. The function does not return

--- a/lib/drift.go
+++ b/lib/drift.go
@@ -106,11 +106,7 @@ func GetResource(ctx context.Context, client *cloudcontrol.Client, typeName stri
 // ListAllResources lists all resources of a given type using Cloud Control API or service-specific APIs.
 // For SSO types it delegates to service-specific functions. For all other types it uses the
 // Cloud Control ListResources API with pagination.
-func ListAllResources(ctx context.Context, typeName string, client CloudControlListResourcesAPI, ssoClient interface {
-	SSOAdminListInstancesAPI
-	SSOAdminListPermissionSetsAPI
-	SSOAdminListAccountAssignmentsAPI
-}, organizationsClient OrganizationsListAccountsAPI) (map[string]string, error) {
+func ListAllResources(ctx context.Context, typeName string, client CloudControlListResourcesAPI, ssoClient SSOAdminClient, organizationsClient OrganizationsListAccountsAPI) (map[string]string, error) {
 	if typeName == "AWS::SSO::PermissionSet" {
 		return GetPermissionSetArns(ctx, ssoClient)
 	}

--- a/lib/interfaces.go
+++ b/lib/interfaces.go
@@ -46,6 +46,13 @@ type SSOAdminListAccountAssignmentsAPI interface {
 	ListAccountAssignments(ctx context.Context, params *ssoadmin.ListAccountAssignmentsInput, optFns ...func(*ssoadmin.Options)) (*ssoadmin.ListAccountAssignmentsOutput, error)
 }
 
+// SSOAdminClient groups the SSO Admin operations needed for drift resource discovery.
+type SSOAdminClient interface {
+	SSOAdminListInstancesAPI
+	SSOAdminListPermissionSetsAPI
+	SSOAdminListAccountAssignmentsAPI
+}
+
 // OrganizationsListAccountsAPI defines the Organizations ListAccounts operation.
 type OrganizationsListAccountsAPI interface {
 	ListAccounts(ctx context.Context, params *organizations.ListAccountsInput, optFns ...func(*organizations.Options)) (*organizations.ListAccountsOutput, error)

--- a/specs/bugfixes/drift-structured-error-handling/report.md
+++ b/specs/bugfixes/drift-structured-error-handling/report.md
@@ -1,0 +1,111 @@
+# Bugfix Report: Drift Structured Error Handling
+
+**Date:** 2026-04-28
+**Status:** Fixed
+
+## Description of the Issue
+
+The `stack drift` command still used `log.Fatal` in two AWS failure paths:
+unmanaged-resource discovery and stack resource loading for special-case drift
+checks. Those exits bypassed the command's normal `failWithError` formatter.
+
+**Reproduction steps:**
+1. Run the drift command with an AWS failure while loading stack resources.
+2. Run the drift command with an AWS failure while listing unmanaged resources.
+3. Observe raw `log.Fatal` output and immediate exit instead of formatted command
+   errors and debug panic handling.
+
+**Impact:** Drift failures were inconsistent with other commands, bypassed the
+normal formatted error flow, and were harder to verify in tests.
+
+## Investigation Summary
+
+The investigation focused on the drift command's error paths and existing test
+coverage around special-case resource handling and unmanaged-resource reporting.
+
+- **Symptoms examined:** raw fatal log output, skipped `failWithError`, and
+  missing debug panic behaviour.
+- **Code inspected:** `cmd/drift.go`, `cmd/helpers.go`,
+  `cmd/drift_specialcases_test.go`, and `cmd/drift_unmanaged_test.go`.
+- **Hypotheses tested:** whether the remaining `log.Fatal` calls were confined
+  to helper paths and whether those helpers could return errors cleanly for the
+  command to handle.
+
+## Discovered Root Cause
+
+The drift command delegated two AWS lookups to code paths that still hard-exited
+with `log.Fatal` instead of returning errors to the main command flow.
+
+**Defect type:** Inconsistent error handling
+
+**Why it occurred:** Earlier drift logic adopted `failWithError`, but the
+special-case stack-resource lookup and unmanaged-resource listing paths were not
+updated to follow the same pattern.
+
+**Contributing factors:** The helper code returned data directly instead of
+returning errors, which made the `log.Fatal` exits harder to test.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `cmd/drift.go` - Returned errors from `separateSpecialCases`, added
+  `detectUnmanagedResources`, and routed both AWS failure paths back through
+  `failWithError`.
+- `cmd/helpers.go` - Switched `failWithError` to use the shared `osExitFunc`
+  hook so command-exit paths remain testable.
+- `cmd/drift_specialcases_test.go` - Added a regression test for
+  `DescribeStackResources` failures.
+- `cmd/drift_unmanaged_test.go` - Added a regression test for unmanaged
+  resource lookup failures.
+
+**Approach rationale:** Returning errors from the helper paths keeps the drift
+command aligned with the rest of the CLI and lets the existing command-level
+error handler control formatting, exit behaviour, and debug panics.
+
+**Alternatives considered:**
+- Keep `log.Fatal` and use subprocess tests - rejected because it preserves the
+  inconsistent command behaviour instead of fixing it.
+
+## Regression Test
+
+**Test file:** `cmd/drift_specialcases_test.go`, `cmd/drift_unmanaged_test.go`
+**Test name:** `TestSeparateSpecialCasesReturnsDescribeStackResourcesError`,
+`TestDetectUnmanagedResourcesReturnsListAllResourcesError`
+
+**What it verifies:** AWS lookup failures return errors for the command-level
+handler instead of hard-exiting via `log.Fatal`.
+
+**Run command:** `go test ./cmd -run 'TestSeparateSpecialCasesReturnsDescribeStackResourcesError|TestDetectUnmanagedResourcesReturnsListAllResourcesError' -count=1`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `cmd/drift.go` | Returned helper errors and centralized unmanaged-resource error handling |
+| `cmd/helpers.go` | Reused the package exit hook from `failWithError` |
+| `cmd/drift_specialcases_test.go` | Added regression coverage for stack resource load failure |
+| `cmd/drift_unmanaged_test.go` | Added regression coverage for unmanaged-resource lookup failure |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Not run
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Prefer returning errors from helper functions and let command entrypoints call
+  `failWithError`.
+- Add focused regression tests whenever command helpers previously terminated
+  the process directly.
+- Reuse testable exit hooks for command-level failures instead of direct fatal
+  logging.
+
+## Related
+
+- Transit ticket `T-1015`


### PR DESCRIPTION
## Summary
- replace drift helper log.Fatal paths with returned errors handled by failWithError
- add regression tests for stack resource loading and unmanaged-resource lookup failures
- document the investigation and resolution in specs/bugfixes/drift-structured-error-handling/report.md

## Root cause
Two AWS error paths in cmd/drift.go still called log.Fatal directly, bypassing the command's formatted error handling and debug panic flow.

## Testing
- go test ./...
- golangci-lint run
- go build -o fog

## Report
- specs/bugfixes/drift-structured-error-handling/report.md