### PR TITLE
Fix T-1026: Guard Nil CloudFormation Pointer Fields

### DIFF
--- a/lib/getcfnstacks_test.go
+++ b/lib/getcfnstacks_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/ArjenSchwarz/fog/lib/testutil"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -91,4 +94,65 @@ func TestGetCfnStacks_SpecificStackFilter(t *testing.T) {
 
 	assert.Len(t, result, 1)
 	assert.Contains(t, result, "my-specific-stack")
+}
+
+func TestGetCfnStacks_ReturnsErrorForMissingStackNameInPaginatedResults(t *testing.T) {
+	client := testutil.NewMockCFNClient()
+	client.DescribeStacksFn = func(ctx context.Context, params *cloudformation.DescribeStacksInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+		switch aws.ToString(params.NextToken) {
+		case "":
+			return &cloudformation.DescribeStacksOutput{
+				Stacks: []types.Stack{{
+					StackName: aws.String("valid-stack"),
+					StackId:   aws.String("stack-id-1"),
+				}},
+				NextToken: aws.String("token2"),
+			}, nil
+		case "token2":
+			return &cloudformation.DescribeStacksOutput{
+				Stacks: []types.Stack{{
+					StackId: aws.String("stack-id-2"),
+				}},
+			}, nil
+		default:
+			return &cloudformation.DescribeStacksOutput{}, nil
+		}
+	}
+
+	filter := ""
+	result, err := GetCfnStacks(context.Background(), &filter, client)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "missing stack name")
+}
+
+func TestGetCfnStacks_ReturnsErrorForMissingStackIDInPaginatedResults(t *testing.T) {
+	client := testutil.NewMockCFNClient()
+	client.DescribeStacksFn = func(ctx context.Context, params *cloudformation.DescribeStacksInput, optFns ...func(*cloudformation.Options)) (*cloudformation.DescribeStacksOutput, error) {
+		switch aws.ToString(params.NextToken) {
+		case "":
+			return &cloudformation.DescribeStacksOutput{
+				Stacks: []types.Stack{{
+					StackName: aws.String("valid-stack"),
+					StackId:   aws.String("stack-id-1"),
+				}},
+				NextToken: aws.String("token2"),
+			}, nil
+		case "token2":
+			return &cloudformation.DescribeStacksOutput{
+				Stacks: []types.Stack{{
+					StackName: aws.String("missing-id-stack"),
+				}},
+			}, nil
+		default:
+			return &cloudformation.DescribeStacksOutput{}, nil
+		}
+	}
+
+	filter := ""
+	result, err := GetCfnStacks(context.Background(), &filter, client)
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "missing stack id")
+	assert.Contains(t, err.Error(), "missing-id-stack")
 }

--- a/lib/outputs.go
+++ b/lib/outputs.go
@@ -104,25 +104,33 @@ func GetExports(ctx context.Context, stackname *string, exportname *string, svc 
 
 func getOutputsForStack(stack types.Stack, stackfilter string, exportfilter string, exportsOnly bool) []CfnOutput {
 	result := []CfnOutput{}
+	stackName := aws.ToString(stack.StackName)
+	if stackName == "" {
+		return result
+	}
 	if strings.Contains(stackfilter, "*") {
-		if !GlobToRegex(stackfilter).MatchString(*stack.StackName) {
+		if !GlobToRegex(stackfilter).MatchString(stackName) {
 			return result
 		}
 	}
 	for _, output := range stack.Outputs {
-		if exportsOnly && aws.ToString(output.ExportName) == "" {
+		exportName := aws.ToString(output.ExportName)
+		if exportsOnly && exportName == "" {
 			continue
 		}
 		if exportfilter != "" {
-			if !GlobToRegex(exportfilter).MatchString(*output.ExportName) {
+			if !GlobToRegex(exportfilter).MatchString(exportName) {
 				continue
 			}
 		}
+		if output.OutputKey == nil || output.OutputValue == nil {
+			continue
+		}
 		parsedOutput := CfnOutput{
-			StackName:   *stack.StackName,
+			StackName:   stackName,
 			OutputKey:   *output.OutputKey,
 			OutputValue: *output.OutputValue,
-			ExportName:  aws.ToString(output.ExportName),
+			ExportName:  exportName,
 		}
 		if output.Description != nil {
 			parsedOutput.Description = *output.Description

--- a/lib/outputs.go
+++ b/lib/outputs.go
@@ -114,6 +114,9 @@ func getOutputsForStack(stack types.Stack, stackfilter string, exportfilter stri
 		}
 	}
 	for _, output := range stack.Outputs {
+		if output.OutputKey == nil || output.OutputValue == nil {
+			continue
+		}
 		exportName := aws.ToString(output.ExportName)
 		if exportsOnly && exportName == "" {
 			continue
@@ -122,9 +125,6 @@ func getOutputsForStack(stack types.Stack, stackfilter string, exportfilter stri
 			if !GlobToRegex(exportfilter).MatchString(exportName) {
 				continue
 			}
-		}
-		if output.OutputKey == nil || output.OutputValue == nil {
-			continue
 		}
 		parsedOutput := CfnOutput{
 			StackName:   stackName,

--- a/lib/outputs_test.go
+++ b/lib/outputs_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock client implementing the interfaces
@@ -325,6 +327,77 @@ func TestGetExportsPagination(t *testing.T) {
 	if _, ok := byName["Export2"]; !ok {
 		t.Error("missing Export2 from second page")
 	}
+}
+
+func TestGetExports_SkipsStacksWithoutStackNameInPaginatedResults(t *testing.T) {
+	stackName := ""
+	mock := paginatingMockCFNClient{
+		pages: map[string]cloudformation.DescribeStacksOutput{
+			"": {
+				Stacks: []types.Stack{{
+					StackName: strPtrOut("stack-page1"),
+					Outputs: []types.Output{
+						{OutputKey: strPtrOut("K1"), OutputValue: strPtrOut("V1"), ExportName: strPtrOut("Export1")},
+					},
+				}},
+				NextToken: strPtrOut("token2"),
+			},
+			"token2": {
+				Stacks: []types.Stack{{
+					Outputs: []types.Output{
+						{OutputKey: strPtrOut("K2"), OutputValue: strPtrOut("V2"), ExportName: strPtrOut("Export2")},
+					},
+				}},
+			},
+		},
+		ImportsByExport: map[string][]string{},
+	}
+
+	results, err := GetExports(context.Background(), &stackName, strPtrOut(""), mock)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "Export1", results[0].ExportName)
+}
+
+func TestGetExports_SkipsOutputsMissingKeyOrValueInPaginatedResults(t *testing.T) {
+	stackName := ""
+	mock := paginatingMockCFNClient{
+		pages: map[string]cloudformation.DescribeStacksOutput{
+			"": {
+				Stacks: []types.Stack{{
+					StackName: strPtrOut("stack-page1"),
+					Outputs: []types.Output{
+						{OutputKey: strPtrOut("K1"), OutputValue: strPtrOut("V1"), ExportName: strPtrOut("Export1")},
+					},
+				}},
+				NextToken: strPtrOut("token2"),
+			},
+			"token2": {
+				Stacks: []types.Stack{{
+					StackName: strPtrOut("stack-page2"),
+					Outputs: []types.Output{
+						{OutputValue: strPtrOut("V2"), ExportName: strPtrOut("Export2")},
+						{OutputKey: strPtrOut("K3"), ExportName: strPtrOut("Export3")},
+						{OutputKey: strPtrOut("K4"), OutputValue: strPtrOut("V4"), ExportName: strPtrOut("Export4")},
+					},
+				}},
+			},
+		},
+		ImportsByExport: map[string][]string{},
+	}
+
+	results, err := GetExports(context.Background(), &stackName, strPtrOut(""), mock)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	byName := map[string]CfnOutput{}
+	for _, result := range results {
+		byName[result.ExportName] = result
+	}
+	assert.Contains(t, byName, "Export1")
+	assert.Contains(t, byName, "Export4")
+	assert.NotContains(t, byName, "Export2")
+	assert.NotContains(t, byName, "Export3")
 }
 
 // TestFillImports_NotImportedError verifies that the specific "is not imported

--- a/lib/resources.go
+++ b/lib/resources.go
@@ -43,8 +43,12 @@ func GetResources(ctx context.Context, stackname *string, svc interface {
 	}
 	tocheckstacks := make([]types.Stack, 0)
 	for _, stack := range allstacks {
+		stackLabel := aws.ToString(stack.StackName)
+		if stackLabel == "" {
+			continue
+		}
 		if strings.Contains(*stackname, "*") {
-			if !GlobToRegex(*stackname).MatchString(*stack.StackName) {
+			if !GlobToRegex(*stackname).MatchString(stackLabel) {
 				continue
 			}
 		}
@@ -52,11 +56,11 @@ func GetResources(ctx context.Context, stackname *string, svc interface {
 	}
 	resourcelist := make([]CfnResource, 0)
 	for _, stack := range tocheckstacks {
+		stackLabel := aws.ToString(stack.StackName)
 		resources, err := svc.DescribeStackResources(
 			ctx,
-			&cloudformation.DescribeStackResourcesInput{StackName: stack.StackName})
+			&cloudformation.DescribeStackResourcesInput{StackName: aws.String(stackLabel)})
 		if err != nil {
-			stackLabel := aws.ToString(stack.StackName)
 			var ae smithy.APIError
 			if errors.As(err, &ae) {
 				// If the error is because of throttling, we'll wait 5 seconds before trying the same query again
@@ -64,7 +68,7 @@ func GetResources(ctx context.Context, stackname *string, svc interface {
 					time.Sleep(5 * time.Second)
 					resources, err = svc.DescribeStackResources(
 						ctx,
-						&cloudformation.DescribeStackResourcesInput{StackName: stack.StackName})
+						&cloudformation.DescribeStackResourcesInput{StackName: aws.String(stackLabel)})
 					// If it still fails after retry, return the error
 					if err != nil {
 						return nil, fmt.Errorf("failed to describe stack resources for %s after throttling retry: %w", stackLabel, err)
@@ -84,7 +88,7 @@ func GetResources(ctx context.Context, stackname *string, svc interface {
 				continue
 			}
 			resitem := CfnResource{
-				StackName:  aws.ToString(stack.StackName),
+				StackName:  stackLabel,
 				Type:       aws.ToString(resource.ResourceType),
 				ResourceID: physicalID,
 				LogicalID:  aws.ToString(resource.LogicalResourceId),

--- a/lib/resources.go
+++ b/lib/resources.go
@@ -59,7 +59,7 @@ func GetResources(ctx context.Context, stackname *string, svc interface {
 		stackLabel := aws.ToString(stack.StackName)
 		resources, err := svc.DescribeStackResources(
 			ctx,
-			&cloudformation.DescribeStackResourcesInput{StackName: aws.String(stackLabel)})
+			&cloudformation.DescribeStackResourcesInput{StackName: stack.StackName})
 		if err != nil {
 			var ae smithy.APIError
 			if errors.As(err, &ae) {
@@ -68,7 +68,7 @@ func GetResources(ctx context.Context, stackname *string, svc interface {
 					time.Sleep(5 * time.Second)
 					resources, err = svc.DescribeStackResources(
 						ctx,
-						&cloudformation.DescribeStackResourcesInput{StackName: aws.String(stackLabel)})
+						&cloudformation.DescribeStackResourcesInput{StackName: stack.StackName})
 					// If it still fails after retry, return the error
 					if err != nil {
 						return nil, fmt.Errorf("failed to describe stack resources for %s after throttling retry: %w", stackLabel, err)

--- a/lib/resources_test.go
+++ b/lib/resources_test.go
@@ -248,6 +248,35 @@ func TestGetResourcesSkipsStacksWithoutNameDuringWildcardFiltering(t *testing.T)
 	assert.Equal(t, 1, mock.describeStackResourcesCalls)
 }
 
+// TestGetResourcesSkipsStacksWithoutNameWhenListingAllStacks verifies that
+// malformed DescribeStacks entries with nil StackName do not panic when listing
+// all stacks and are ignored.
+func TestGetResourcesSkipsStacksWithoutNameWhenListingAllStacks(t *testing.T) {
+	stackName := ""
+	mock := &paginatingMockClient{
+		pages: map[string]cloudformation.DescribeStacksOutput{
+			"": {
+				Stacks:    []types.Stack{{StackName: aws.String("stack-page1")}},
+				NextToken: aws.String("token2"),
+			},
+			"token2": {
+				Stacks: []types.Stack{{}},
+			},
+		},
+		describeStackResourcesOutputs: []cloudformation.DescribeStackResourcesOutput{
+			{StackResources: []types.StackResource{
+				{LogicalResourceId: aws.String("R1"), PhysicalResourceId: aws.String("p1"), ResourceType: aws.String("AWS::S3::Bucket"), ResourceStatus: types.ResourceStatusCreateComplete},
+			}},
+		},
+	}
+
+	got, err := GetResources(context.Background(), &stackName, mock)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "stack-page1", got[0].StackName)
+	assert.Equal(t, 1, mock.describeStackResourcesCalls)
+}
+
 // TestGetResourcesSkipsMissingPhysicalResourceID verifies that resources without a usable physical ID are ignored.
 func TestGetResourcesSkipsMissingPhysicalResourceID(t *testing.T) {
 	stackName := "nil-physical-id-stack"

--- a/lib/resources_test.go
+++ b/lib/resources_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/smithy-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockCloudFormationClient implements the CloudFormation interfaces for testing.
@@ -215,6 +217,35 @@ func TestGetResourcesPagination(t *testing.T) {
 	if mock.describeStackResourcesCalls != 3 {
 		t.Errorf("expected 3 DescribeStackResources calls (one per stack), got %d", mock.describeStackResourcesCalls)
 	}
+}
+
+// TestGetResourcesSkipsStacksWithoutNameDuringWildcardFiltering verifies that
+// malformed DescribeStacks entries with nil StackName do not panic wildcard
+// filtering and are ignored.
+func TestGetResourcesSkipsStacksWithoutNameDuringWildcardFiltering(t *testing.T) {
+	stackName := "stack-*"
+	mock := &paginatingMockClient{
+		pages: map[string]cloudformation.DescribeStacksOutput{
+			"": {
+				Stacks: []types.Stack{{StackName: aws.String("stack-page1")}},
+				NextToken: aws.String("token2"),
+			},
+			"token2": {
+				Stacks: []types.Stack{{}},
+			},
+		},
+		describeStackResourcesOutputs: []cloudformation.DescribeStackResourcesOutput{
+			{StackResources: []types.StackResource{
+				{LogicalResourceId: aws.String("R1"), PhysicalResourceId: aws.String("p1"), ResourceType: aws.String("AWS::S3::Bucket"), ResourceStatus: types.ResourceStatusCreateComplete},
+			}},
+		},
+	}
+
+	got, err := GetResources(context.Background(), &stackName, mock)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "stack-page1", got[0].StackName)
+	assert.Equal(t, 1, mock.describeStackResourcesCalls)
 }
 
 // TestGetResourcesSkipsMissingPhysicalResourceID verifies that resources without a usable physical ID are ignored.

--- a/lib/resources_test.go
+++ b/lib/resources_test.go
@@ -227,7 +227,7 @@ func TestGetResourcesSkipsStacksWithoutNameDuringWildcardFiltering(t *testing.T)
 	mock := &paginatingMockClient{
 		pages: map[string]cloudformation.DescribeStacksOutput{
 			"": {
-				Stacks: []types.Stack{{StackName: aws.String("stack-page1")}},
+				Stacks:    []types.Stack{{StackName: aws.String("stack-page1")}},
 				NextToken: aws.String("token2"),
 			},
 			"token2": {

--- a/lib/stacks.go
+++ b/lib/stacks.go
@@ -231,18 +231,27 @@ func GetCfnStacks(ctx context.Context, stackname *string, svc CFNExportsAPI) (ma
 	}
 	tocheckstacks := make([]types.Stack, 0)
 	for _, stack := range allstacks {
+		stackLabel := aws.ToString(stack.StackName)
+		if stackLabel == "" {
+			return nil, fmt.Errorf("invalid CloudFormation stack in DescribeStacks response: missing stack name")
+		}
 		if strings.Contains(*stackname, "*") {
-			if !GlobToRegex(*stackname).MatchString(*stack.StackName) {
+			if !GlobToRegex(*stackname).MatchString(stackLabel) {
 				continue
 			}
 		}
 		tocheckstacks = append(tocheckstacks, stack)
 	}
 	for _, stack := range tocheckstacks {
+		stackNameValue := aws.ToString(stack.StackName)
+		stackIDValue := aws.ToString(stack.StackId)
+		if stackIDValue == "" {
+			return nil, fmt.Errorf("invalid CloudFormation stack %q in DescribeStacks response: missing stack id", stackNameValue)
+		}
 		stackobject := CfnStack{
 			RawInfo: stack,
-			Name:    *stack.StackName,
-			Id:      *stack.StackId,
+			Name:    stackNameValue,
+			Id:      stackIDValue,
 		}
 		if stack.Description != nil {
 			stackobject.Description = *stack.Description
@@ -250,14 +259,14 @@ func GetCfnStacks(ctx context.Context, stackname *string, svc CFNExportsAPI) (ma
 		outputs := getOutputsForStack(stack, "", "", false)
 		for i := range outputs {
 			if err := outputs[i].FillImports(ctx, svc); err != nil {
-				return nil, fmt.Errorf("stack %q: %w", *stack.StackName, err)
+				return nil, fmt.Errorf("stack %q: %w", stackNameValue, err)
 			}
 			if outputs[i].Imported {
 				stackobject.ImportedBy = append(stackobject.ImportedBy, outputs[i].ImportedBy...)
 			}
 		}
 		stackobject.Outputs = outputs
-		result[*stack.StackName] = stackobject
+		result[stackNameValue] = stackobject
 	}
 	return result, nil
 }

--- a/lib/stacks.go
+++ b/lib/stacks.go
@@ -231,25 +231,25 @@ func GetCfnStacks(ctx context.Context, stackname *string, svc CFNExportsAPI) (ma
 	}
 	tocheckstacks := make([]types.Stack, 0)
 	for _, stack := range allstacks {
-		stackLabel := aws.ToString(stack.StackName)
-		if stackLabel == "" {
+		stackName := aws.ToString(stack.StackName)
+		if stackName == "" {
 			return nil, fmt.Errorf("invalid CloudFormation stack in DescribeStacks response: missing stack name")
 		}
 		if aws.ToString(stack.StackId) == "" {
-			return nil, fmt.Errorf("invalid CloudFormation stack %q in DescribeStacks response: missing stack id", stackLabel)
+			return nil, fmt.Errorf("invalid CloudFormation stack %q in DescribeStacks response: missing stack id", stackName)
 		}
 		if strings.Contains(*stackname, "*") {
-			if !GlobToRegex(*stackname).MatchString(stackLabel) {
+			if !GlobToRegex(*stackname).MatchString(stackName) {
 				continue
 			}
 		}
 		tocheckstacks = append(tocheckstacks, stack)
 	}
 	for _, stack := range tocheckstacks {
-		stackNameValue := aws.ToString(stack.StackName)
+		stackName := aws.ToString(stack.StackName)
 		stackobject := CfnStack{
 			RawInfo: stack,
-			Name:    stackNameValue,
+			Name:    stackName,
 			Id:      aws.ToString(stack.StackId),
 		}
 		if stack.Description != nil {
@@ -258,14 +258,14 @@ func GetCfnStacks(ctx context.Context, stackname *string, svc CFNExportsAPI) (ma
 		outputs := getOutputsForStack(stack, "", "", false)
 		for i := range outputs {
 			if err := outputs[i].FillImports(ctx, svc); err != nil {
-				return nil, fmt.Errorf("stack %q: %w", stackNameValue, err)
+				return nil, fmt.Errorf("stack %q: %w", stackName, err)
 			}
 			if outputs[i].Imported {
 				stackobject.ImportedBy = append(stackobject.ImportedBy, outputs[i].ImportedBy...)
 			}
 		}
 		stackobject.Outputs = outputs
-		result[stackNameValue] = stackobject
+		result[stackName] = stackobject
 	}
 	return result, nil
 }

--- a/lib/stacks.go
+++ b/lib/stacks.go
@@ -235,6 +235,9 @@ func GetCfnStacks(ctx context.Context, stackname *string, svc CFNExportsAPI) (ma
 		if stackLabel == "" {
 			return nil, fmt.Errorf("invalid CloudFormation stack in DescribeStacks response: missing stack name")
 		}
+		if aws.ToString(stack.StackId) == "" {
+			return nil, fmt.Errorf("invalid CloudFormation stack %q in DescribeStacks response: missing stack id", stackLabel)
+		}
 		if strings.Contains(*stackname, "*") {
 			if !GlobToRegex(*stackname).MatchString(stackLabel) {
 				continue
@@ -244,14 +247,10 @@ func GetCfnStacks(ctx context.Context, stackname *string, svc CFNExportsAPI) (ma
 	}
 	for _, stack := range tocheckstacks {
 		stackNameValue := aws.ToString(stack.StackName)
-		stackIDValue := aws.ToString(stack.StackId)
-		if stackIDValue == "" {
-			return nil, fmt.Errorf("invalid CloudFormation stack %q in DescribeStacks response: missing stack id", stackNameValue)
-		}
 		stackobject := CfnStack{
 			RawInfo: stack,
 			Name:    stackNameValue,
-			Id:      stackIDValue,
+			Id:      aws.ToString(stack.StackId),
 		}
 		if stack.Description != nil {
 			stackobject.Description = *stack.Description

--- a/specs/bugfixes/guard-nil-cloudformation-pointer-fields/report.md
+++ b/specs/bugfixes/guard-nil-cloudformation-pointer-fields/report.md
@@ -1,0 +1,114 @@
+# Bugfix Report: Guard nil CloudFormation pointer fields
+
+**Date:** 2026-04-28
+**Status:** Investigating
+
+## Description of the Issue
+
+Several CloudFormation listing helpers dereference AWS SDK pointer fields without
+checking for nil first. When AWS returns partial data, or tests inject malformed
+stack/output records, the code panics instead of degrading gracefully or
+returning a useful error.
+
+**Reproduction steps:**
+1. Call `GetCfnStacks`, `GetExports`, or `GetResources` with paginated
+   `DescribeStacks` results that include malformed stack/output entries.
+2. Include entries with nil `StackName`, nil `StackId`, nil `OutputKey`, or nil
+   `OutputValue`.
+3. Observe a panic caused by direct pointer dereferences in the listing code.
+
+**Impact:** Stack, export, and resource listing commands can crash on malformed
+or partial CloudFormation responses instead of returning usable data or a
+contextual error.
+
+## Investigation Summary
+
+The investigation focused on the stack, export, and resource listing helpers
+named in Transit ticket T-1026.
+
+- **Symptoms examined:** panics while iterating paginated `DescribeStacks`
+  results containing nil pointer fields.
+- **Code inspected:** `lib/stacks.go`, `lib/outputs.go`, `lib/resources.go`,
+  and their associated unit tests.
+- **Hypotheses tested:** whether each code path should skip malformed entries or
+  return contextual errors, and whether paginated tests can reproduce the bug
+  consistently.
+
+## Discovered Root Cause
+
+The AWS SDK models CloudFormation fields like `StackName`, `StackId`,
+`OutputKey`, and `OutputValue` as pointers, but the affected functions treat
+them as always present and dereference them directly.
+
+**Defect type:** Missing validation
+
+**Why it occurred:** The listing helpers assume normal AWS responses and do not
+guard malformed or partial objects before filtering, constructing result
+records, or formatting error messages.
+
+**Contributing factors:** Existing tests covered happy paths and pagination, but
+did not cover nil pointer fields inside paginated responses.
+
+## Resolution for the Issue
+
+**Changes made:**
+- _Pending implementation._
+
+**Approach rationale:** _Pending implementation._
+
+**Alternatives considered:**
+- Return errors for every malformed stack/output entry - likely too disruptive
+  for export/resource listings that can safely skip incomplete records.
+
+## Regression Test
+
+**Test file:** `lib/getcfnstacks_test.go`, `lib/outputs_test.go`,
+`lib/resources_test.go`
+**Test name:** `TestGetCfnStacks_ReturnsErrorForMissingStackNameInPaginatedResults`,
+`TestGetCfnStacks_ReturnsErrorForMissingStackIDInPaginatedResults`,
+`TestGetExports_SkipsStacksWithoutStackNameInPaginatedResults`,
+`TestGetExports_SkipsOutputsMissingKeyOrValueInPaginatedResults`,
+`TestGetResourcesSkipsStacksWithoutNameDuringWildcardFiltering`
+
+**What it verifies:** Malformed paginated stack/output records do not panic;
+callers either receive a contextual error (`GetCfnStacks`) or malformed entries
+are skipped (`GetExports`, `GetResources`).
+
+**Run command:** `go test ./lib -run 'TestGetCfnStacks_ReturnsErrorForMissingStack(Name|ID)InPaginatedResults|TestGetExports_SkipsStacksWithoutStackNameInPaginatedResults|TestGetExports_SkipsOutputsMissingKeyOrValueInPaginatedResults|TestGetResourcesSkipsStacksWithoutNameDuringWildcardFiltering'`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/stacks.go` | Pending nil-guard fix for stack listing |
+| `lib/outputs.go` | Pending nil-guard fix for export parsing |
+| `lib/resources.go` | Pending nil-guard fix for resource filtering |
+| `lib/getcfnstacks_test.go` | Added failing regression coverage |
+| `lib/outputs_test.go` | Added failing regression coverage |
+| `lib/resources_test.go` | Added failing regression coverage |
+
+## Verification
+
+**Automated:**
+- [x] Regression test fails before fix
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+**Manual verification:**
+- Reviewed the panic traces from the new regression tests to confirm they point
+  at the direct pointer dereferences described in T-1026.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Prefer `aws.ToString` or explicit nil guards whenever AWS SDK response fields
+  are pointer-typed.
+- Add regression tests for malformed paginated SDK responses when touching list
+  aggregation code.
+- Favor contextual errors for malformed entries that are required for correct
+  downstream behavior, and skipping for optional/incomplete list items.
+
+## Related
+
+- Transit ticket `T-1026`

--- a/specs/bugfixes/guard-nil-cloudformation-pointer-fields/report.md
+++ b/specs/bugfixes/guard-nil-cloudformation-pointer-fields/report.md
@@ -1,7 +1,7 @@
 # Bugfix Report: Guard nil CloudFormation pointer fields
 
 **Date:** 2026-04-28
-**Status:** Investigating
+**Status:** Fixed
 
 ## Description of the Issue
 
@@ -52,9 +52,24 @@ did not cover nil pointer fields inside paginated responses.
 ## Resolution for the Issue
 
 **Changes made:**
-- _Pending implementation._
+- `lib/stacks.go:232-269` - validate stack names and stack IDs before building
+  `CfnStack` results, returning contextual errors for malformed stack records.
+- `lib/outputs.go:105-139` - use nil-safe stack/export name handling and skip
+  outputs missing required key/value fields instead of panicking.
+- `lib/resources.go:44-97` - skip stacks without usable names during filtering
+  and use safe stack labels for resource lookups and error messages.
+- `lib/getcfnstacks_test.go` - added paginated regression coverage for nil
+  `StackName` and nil `StackId`.
+- `lib/outputs_test.go` - added paginated regression coverage for nil
+  `StackName`, nil `OutputKey`, and nil `OutputValue`.
+- `lib/resources_test.go` - added wildcard-filter regression coverage for nil
+  `StackName`.
 
-**Approach rationale:** _Pending implementation._
+**Approach rationale:** `GetCfnStacks` now returns explicit errors because stack
+name and stack ID are required to build correct `CfnStack` results and support
+downstream event lookups. `GetExports` and `GetResources` skip malformed items
+because those listings can still return useful results from the remaining valid
+entries.
 
 **Alternatives considered:**
 - Return errors for every malformed stack/output entry - likely too disruptive
@@ -80,24 +95,24 @@ are skipped (`GetExports`, `GetResources`).
 
 | File | Change |
 |------|--------|
-| `lib/stacks.go` | Pending nil-guard fix for stack listing |
-| `lib/outputs.go` | Pending nil-guard fix for export parsing |
-| `lib/resources.go` | Pending nil-guard fix for resource filtering |
-| `lib/getcfnstacks_test.go` | Added failing regression coverage |
-| `lib/outputs_test.go` | Added failing regression coverage |
-| `lib/resources_test.go` | Added failing regression coverage |
+| `lib/stacks.go` | Added contextual validation for missing stack name and stack ID |
+| `lib/outputs.go` | Guarded stack/output pointers and skip malformed export entries |
+| `lib/resources.go` | Guarded wildcard filtering and stack resource lookups |
+| `lib/getcfnstacks_test.go` | Added regression coverage for missing stack identifiers |
+| `lib/outputs_test.go` | Added regression coverage for malformed export records |
+| `lib/resources_test.go` | Added regression coverage for nil stack names during wildcard filtering |
 
 ## Verification
 
 **Automated:**
 - [x] Regression test fails before fix
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
 
 **Manual verification:**
-- Reviewed the panic traces from the new regression tests to confirm they point
-  at the direct pointer dereferences described in T-1026.
+- Reviewed the pre-fix panic traces and post-fix behavior to confirm malformed
+  paginated entries are now either skipped or converted into contextual errors.
 
 ## Prevention
 


### PR DESCRIPTION
## Summary
- guard nil CloudFormation stack pointer fields in stack, export, and resource listings
- return contextual errors for malformed stacks in GetCfnStacks and skip malformed entries in export/resource listings
- add paginated regression tests and document the investigation in specs/bugfixes/guard-nil-cloudformation-pointer-fields/report.md

## Root cause
These listing helpers dereferenced AWS SDK pointer fields like StackName, StackId, OutputKey, and OutputValue without validating them first, so malformed paginated responses panicked.

## Verification
- go test ./...
- golangci-lint run
- go build -o fog
