### PR TITLE
[bug] Fix T-1071: Block Wrapped Unsafe Precheck Commands

### DIFF
--- a/lib/files.go
+++ b/lib/files.go
@@ -248,7 +248,7 @@ func hasUnquotedCommandOperators(commandString string) bool {
 			inDouble = !inDouble
 		case !inSingle && !inDouble:
 			switch c {
-			case ';', '|', '&', '\n', '\r', '<', '>', '(', ')':
+			case ';', '|', '&', '\n', '\r', '<', '>', '(', ')', '`':
 				return true
 			}
 		}

--- a/lib/files.go
+++ b/lib/files.go
@@ -139,6 +139,144 @@ func splitShellArgs(s string) ([]string, error) {
 	return args, nil
 }
 
+var blockedPrecheckCommands = []string{"rm", "del", "kill"}
+
+func normalizePrecheckCommandName(command string) string {
+	return strings.ToLower(filepath.Base(command))
+}
+
+func findUnsafeWrappedPrecheck(args []string) (string, error) {
+	for len(args) > 0 {
+		command := args[0]
+		commandName := normalizePrecheckCommandName(command)
+		if stringInSlice(commandName, blockedPrecheckCommands) {
+			return command, nil
+		}
+
+		var (
+			nextArgs []string
+			err      error
+		)
+		switch commandName {
+		case "env":
+			nextArgs, err = unwrapEnvCommand(args[1:])
+		case "sh", "bash", "zsh", "dash", "ksh", "ash":
+			nextArgs, err = unwrapShellCommand(args[1:])
+		case "cmd", "cmd.exe":
+			nextArgs, err = unwrapCmdCommand(args[1:])
+		case "powershell", "powershell.exe", "pwsh", "pwsh.exe":
+			nextArgs, err = unwrapPowerShellCommand(args[1:])
+		default:
+			return "", nil
+		}
+		if err != nil {
+			return "", err
+		}
+		if len(nextArgs) == 0 {
+			return "", nil
+		}
+		args = nextArgs
+	}
+
+	return "", nil
+}
+
+func unwrapEnvCommand(args []string) ([]string, error) {
+	for i := 0; i < len(args); {
+		arg := args[i]
+		switch {
+		case arg == "--":
+			if i+1 >= len(args) {
+				return nil, nil
+			}
+			return args[i+1:], nil
+		case arg == "-S" || arg == "--split-string":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("env wrapper missing command after %q", arg)
+			}
+			return splitShellArgs(args[i+1])
+		case arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir":
+			i += 2
+		case strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir="):
+			i++
+		case arg == "-i" || arg == "--ignore-environment" || arg == "-0" || arg == "--null" || arg == "-v" || arg == "--debug":
+			i++
+		case strings.Contains(arg, "=") && !strings.HasPrefix(arg, "="):
+			i++
+		default:
+			return args[i:], nil
+		}
+	}
+
+	return nil, nil
+}
+
+func unwrapShellCommand(args []string) ([]string, error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-c":
+			if i+1 >= len(args) {
+				return nil, nil
+			}
+			return splitShellArgs(args[i+1])
+		case strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") && strings.Contains(strings.TrimPrefix(arg, "-"), "c"):
+			if i+1 >= len(args) {
+				return nil, nil
+			}
+			return splitShellArgs(args[i+1])
+		case arg == "-o" || arg == "-O" || arg == "--rcfile" || arg == "--init-file":
+			i++
+		case strings.HasPrefix(arg, "--rcfile=") || strings.HasPrefix(arg, "--init-file="):
+			continue
+		case arg == "--":
+			return nil, nil
+		case strings.HasPrefix(arg, "-"):
+			continue
+		default:
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func unwrapCmdCommand(args []string) ([]string, error) {
+	for i, arg := range args {
+		if !strings.EqualFold(arg, "/c") && !strings.EqualFold(arg, "/k") {
+			continue
+		}
+		if i+1 >= len(args) {
+			return nil, nil
+		}
+		rest := args[i+1:]
+		if len(rest) == 1 {
+			return splitShellArgs(rest[0])
+		}
+		return rest, nil
+	}
+
+	return nil, nil
+}
+
+func unwrapPowerShellCommand(args []string) ([]string, error) {
+	for i, arg := range args {
+		if !strings.EqualFold(arg, "-command") && !strings.EqualFold(arg, "-c") {
+			continue
+		}
+		if i+1 >= len(args) {
+			return nil, nil
+		}
+		rest := args[i+1:]
+		if len(rest) == 1 {
+			return splitShellArgs(rest[0])
+		}
+		return rest, nil
+	}
+
+	return nil, nil
+}
+
 // RunPrechecks executes configured template validation commands and returns results for each check.
 func RunPrechecks(deployment *DeployInfo) (map[string]string, error) {
 	results := make(map[string]string)
@@ -152,13 +290,10 @@ func RunPrechecks(deployment *DeployInfo) (map[string]string, error) {
 			return results, fmt.Errorf("precheck command is empty or only whitespace: %q", precheck)
 		}
 		command, args := separated[0], separated[1:]
-		// Normalise the executable name so that path-prefixed invocations
-		// (e.g. /bin/rm, ./rm) are caught by the denylist.
-		// NOTE: this denylist is intentionally minimal; an allowlist approach would
-		// provide stronger guarantees (see specs/bugfixes/block-unsafe-precheck-path/report.md).
-		baseName := strings.ToLower(filepath.Base(command))
-		if stringInSlice(baseName, []string{"rm", "del", "kill"}) {
-			return results, fmt.Errorf("unsafe command '%v' detected", command)
+		if unsafeCommand, err := findUnsafeWrappedPrecheck(separated); err != nil {
+			return results, err
+		} else if unsafeCommand != "" {
+			return results, fmt.Errorf("unsafe command '%v' detected", unsafeCommand)
 		}
 		binary, lookErr := exec.LookPath(command)
 		if lookErr != nil {

--- a/lib/files.go
+++ b/lib/files.go
@@ -144,8 +144,18 @@ func splitShellArgs(s string) ([]string, error) {
 // blockedPrecheckCommands are never allowed to run as prechecks, even when a
 // wrapper binary delegates execution to them. Wrapper inspection is
 // intentionally conservative: command strings are only unwrapped when they can
-// be reduced to a single argv vector without shell-style control operators.
+// be reduced to a single argv vector without wrapper-specific control
+// operators. This is still a best-effort deny-list; an allowlist would provide
+// stronger guarantees than trying to model every possible passthrough wrapper.
 var blockedPrecheckCommands = []string{"rm", "del", "kill"}
+
+type wrappedCommandDialect int
+
+const (
+	wrappedCommandShell wrappedCommandDialect = iota
+	wrappedCommandCmd
+	wrappedCommandPowerShell
+)
 
 func normalizePrecheckCommandName(command string) string {
 	name := strings.ToLower(filepath.Base(command))
@@ -206,9 +216,9 @@ func unwrapEnvCommand(args []string) ([]string, error) {
 			if i+1 >= len(args) {
 				return nil, fmt.Errorf("env wrapper missing command after %q", arg)
 			}
-			return splitShellArgs(args[i+1])
+			return parseWrappedCommandString(args[i+1], "env -S", wrappedCommandShell)
 		case strings.HasPrefix(arg, "--split-string="):
-			return splitShellArgs(strings.TrimPrefix(arg, "--split-string="))
+			return parseWrappedCommandString(strings.TrimPrefix(arg, "--split-string="), "env -S", wrappedCommandShell)
 		case arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" || arg == "-a" || arg == "--argv0":
 			i += 2
 		case strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir=") || strings.HasPrefix(arg, "--argv0="):
@@ -225,14 +235,14 @@ func unwrapEnvCommand(args []string) ([]string, error) {
 	return nil, nil
 }
 
-func parseWrappedCommandString(commandString string, wrapper string) ([]string, error) {
-	if hasUnquotedCommandOperators(commandString) {
+func parseWrappedCommandString(commandString string, wrapper string, dialect wrappedCommandDialect) ([]string, error) {
+	if hasUnquotedCommandOperators(commandString, dialect) {
 		return nil, fmt.Errorf("%s command strings cannot be safely unwrapped for precheck", wrapper)
 	}
 	return splitShellArgs(commandString)
 }
 
-func hasUnquotedCommandOperators(commandString string) bool {
+func hasUnquotedCommandOperators(commandString string, dialect wrappedCommandDialect) bool {
 	inSingle := false
 	inDouble := false
 	escaped := false
@@ -242,21 +252,42 @@ func hasUnquotedCommandOperators(commandString string) bool {
 		switch {
 		case escaped:
 			escaped = false
-		case c == '\\' && !inSingle:
+		case isWrappedCommandEscape(c, dialect, inSingle):
 			escaped = true
-		case c == '\'' && !inDouble:
+		case c == '\'' && dialect != wrappedCommandCmd && !inDouble:
 			inSingle = !inSingle
 		case c == '"' && !inSingle:
 			inDouble = !inDouble
-		case !inSingle && !inDouble:
-			switch c {
-			case ';', '|', '&', '\n', '\r', '<', '>', '(', ')', '`':
-				return true
-			}
+		case !inSingle && !inDouble && isWrappedCommandOperator(c, dialect):
+			return true
 		}
 	}
 
 	return false
+}
+
+func isWrappedCommandEscape(c byte, dialect wrappedCommandDialect, inSingle bool) bool {
+	switch dialect {
+	case wrappedCommandShell:
+		return c == '\\' && !inSingle
+	case wrappedCommandCmd:
+		return c == '^'
+	case wrappedCommandPowerShell:
+		return c == '`' && !inSingle
+	default:
+		return false
+	}
+}
+
+func isWrappedCommandOperator(c byte, dialect wrappedCommandDialect) bool {
+	switch dialect {
+	case wrappedCommandCmd:
+		return c == '|' || c == '&' || c == '\n' || c == '\r' || c == '<' || c == '>' || c == '(' || c == ')'
+	case wrappedCommandPowerShell:
+		return c == ';' || c == '|' || c == '&' || c == '\n' || c == '\r' || c == '<' || c == '>' || c == '(' || c == ')'
+	default:
+		return c == ';' || c == '|' || c == '&' || c == '\n' || c == '\r' || c == '<' || c == '>' || c == '(' || c == ')' || c == '`'
+	}
 }
 
 func unwrapShellShortOptions(arg string, args []string, index *int) ([]string, error) {
@@ -270,7 +301,7 @@ func unwrapShellShortOptions(arg string, args []string, index *int) ([]string, e
 			if *index+1 >= len(args) {
 				return nil, nil
 			}
-			return parseWrappedCommandString(args[*index+1], "shell -c")
+			return parseWrappedCommandString(args[*index+1], "shell -c", wrappedCommandShell)
 		case 'o', 'O':
 			if pos+1 < len(shortOpts) {
 				return nil, nil
@@ -291,7 +322,7 @@ func unwrapShellCommand(args []string) ([]string, error) {
 			if i+1 >= len(args) {
 				return nil, nil
 			}
-			return parseWrappedCommandString(args[i+1], "shell -c")
+			return parseWrappedCommandString(args[i+1], "shell -c", wrappedCommandShell)
 		case arg == "-o" || arg == "-O" || arg == "--rcfile" || arg == "--init-file":
 			i++
 		case strings.HasPrefix(arg, "--rcfile=") || strings.HasPrefix(arg, "--init-file="):
@@ -325,7 +356,7 @@ func unwrapCmdCommand(args []string) ([]string, error) {
 		if i+1 >= len(args) {
 			return nil, nil
 		}
-		return parseWrappedCommandString(strings.Join(args[i+1:], " "), "cmd")
+		return parseWrappedCommandString(strings.Join(args[i+1:], " "), "cmd", wrappedCommandCmd)
 	}
 
 	return nil, nil
@@ -378,14 +409,14 @@ func unwrapPowerShellCommand(args []string) ([]string, error) {
 			if err != nil {
 				return nil, err
 			}
-			return parseWrappedCommandString(commandString, "PowerShell encoded")
+			return parseWrappedCommandString(commandString, "PowerShell encoded", wrappedCommandPowerShell)
 		case isPowerShellFileFlag(arg):
 			return nil, fmt.Errorf("PowerShell -File commands cannot be safely unwrapped for precheck")
 		case isPowerShellCommandFlag(arg):
 			if i+1 >= len(args) {
 				return nil, nil
 			}
-			return parseWrappedCommandString(strings.Join(args[i+1:], " "), "PowerShell")
+			return parseWrappedCommandString(strings.Join(args[i+1:], " "), "PowerShell", wrappedCommandPowerShell)
 		}
 	}
 

--- a/lib/files.go
+++ b/lib/files.go
@@ -207,9 +207,9 @@ func unwrapEnvCommand(args []string) ([]string, error) {
 				return nil, fmt.Errorf("env wrapper missing command after %q", arg)
 			}
 			return splitShellArgs(args[i+1])
-		case arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir":
+		case arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" || arg == "-a" || arg == "--argv0":
 			i += 2
-		case strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir="):
+		case strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir=") || strings.HasPrefix(arg, "--argv0="):
 			i++
 		case arg == "-i" || arg == "--ignore-environment" || arg == "-0" || arg == "--null" || arg == "-v" || arg == "--debug":
 			i++
@@ -347,6 +347,11 @@ func isPowerShellEncodedCommandFlag(arg string) bool {
 	return lowerArg == "-enc" || matchesPowerShellFlagPrefix(lowerArg, "-encodedcommand", "-enc")
 }
 
+func isPowerShellFileFlag(arg string) bool {
+	lowerArg := strings.ToLower(arg)
+	return lowerArg == "-f" || matchesPowerShellFlagPrefix(lowerArg, "-file", "-fi")
+}
+
 func decodePowerShellEncodedCommand(encoded string) (string, error) {
 	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
@@ -376,6 +381,8 @@ func unwrapPowerShellCommand(args []string) ([]string, error) {
 				return nil, err
 			}
 			return parseWrappedCommandString(commandString, "PowerShell encoded")
+		case isPowerShellFileFlag(arg):
+			return nil, fmt.Errorf("PowerShell -File commands cannot be safely unwrapped for precheck")
 		case isPowerShellCommandFlag(arg):
 			if i+1 >= len(args) {
 				return nil, nil

--- a/lib/files.go
+++ b/lib/files.go
@@ -3,6 +3,7 @@ package lib
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf16"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -139,10 +141,20 @@ func splitShellArgs(s string) ([]string, error) {
 	return args, nil
 }
 
+// blockedPrecheckCommands are never allowed to run as prechecks, even when a
+// wrapper binary delegates execution to them. Wrapper inspection is
+// intentionally conservative: command strings are only unwrapped when they can
+// be reduced to a single argv vector without shell-style control operators.
 var blockedPrecheckCommands = []string{"rm", "del", "kill"}
 
 func normalizePrecheckCommandName(command string) string {
-	return strings.ToLower(filepath.Base(command))
+	name := strings.ToLower(filepath.Base(command))
+	switch filepath.Ext(name) {
+	case ".exe", ".bat", ".cmd":
+		return strings.TrimSuffix(name, filepath.Ext(name))
+	default:
+		return name
+	}
 }
 
 func findUnsafeWrappedPrecheck(args []string) (string, error) {
@@ -162,9 +174,9 @@ func findUnsafeWrappedPrecheck(args []string) (string, error) {
 			nextArgs, err = unwrapEnvCommand(args[1:])
 		case "sh", "bash", "zsh", "dash", "ksh", "ash":
 			nextArgs, err = unwrapShellCommand(args[1:])
-		case "cmd", "cmd.exe":
+		case "cmd":
 			nextArgs, err = unwrapCmdCommand(args[1:])
-		case "powershell", "powershell.exe", "pwsh", "pwsh.exe":
+		case "powershell", "pwsh":
 			nextArgs, err = unwrapPowerShellCommand(args[1:])
 		default:
 			return "", nil
@@ -211,6 +223,64 @@ func unwrapEnvCommand(args []string) ([]string, error) {
 	return nil, nil
 }
 
+func parseWrappedCommandString(commandString string, wrapper string) ([]string, error) {
+	if hasUnquotedCommandOperators(commandString) {
+		return nil, fmt.Errorf("%s command strings cannot be safely unwrapped for precheck", wrapper)
+	}
+	return splitShellArgs(commandString)
+}
+
+func hasUnquotedCommandOperators(commandString string) bool {
+	inSingle := false
+	inDouble := false
+	escaped := false
+
+	for i := 0; i < len(commandString); i++ {
+		c := commandString[i]
+		switch {
+		case escaped:
+			escaped = false
+		case c == '\\' && !inSingle:
+			escaped = true
+		case c == '\'' && !inDouble:
+			inSingle = !inSingle
+		case c == '"' && !inSingle:
+			inDouble = !inDouble
+		case !inSingle && !inDouble:
+			switch c {
+			case ';', '|', '&', '\n', '\r', '<', '>', '(', ')':
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func unwrapShellShortOptions(arg string, args []string, index *int) ([]string, error) {
+	shortOpts := strings.TrimPrefix(arg, "-")
+	for pos := 0; pos < len(shortOpts); pos++ {
+		switch shortOpts[pos] {
+		case 'c':
+			if pos != len(shortOpts)-1 {
+				return nil, nil
+			}
+			if *index+1 >= len(args) {
+				return nil, nil
+			}
+			return parseWrappedCommandString(args[*index+1], "shell -c")
+		case 'o', 'O':
+			if pos+1 < len(shortOpts) {
+				return nil, nil
+			}
+			*index++
+			return nil, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func unwrapShellCommand(args []string) ([]string, error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -219,19 +289,23 @@ func unwrapShellCommand(args []string) ([]string, error) {
 			if i+1 >= len(args) {
 				return nil, nil
 			}
-			return splitShellArgs(args[i+1])
-		case strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") && strings.Contains(strings.TrimPrefix(arg, "-"), "c"):
-			if i+1 >= len(args) {
-				return nil, nil
-			}
-			return splitShellArgs(args[i+1])
+			return parseWrappedCommandString(args[i+1], "shell -c")
 		case arg == "-o" || arg == "-O" || arg == "--rcfile" || arg == "--init-file":
 			i++
 		case strings.HasPrefix(arg, "--rcfile=") || strings.HasPrefix(arg, "--init-file="):
 			continue
 		case arg == "--":
 			return nil, nil
+		case strings.HasPrefix(arg, "--"):
+			continue
 		case strings.HasPrefix(arg, "-"):
+			nextArgs, err := unwrapShellShortOptions(arg, args, &i)
+			if err != nil {
+				return nil, err
+			}
+			if len(nextArgs) > 0 {
+				return nextArgs, nil
+			}
 			continue
 		default:
 			return nil, nil
@@ -259,19 +333,59 @@ func unwrapCmdCommand(args []string) ([]string, error) {
 	return nil, nil
 }
 
+func matchesPowerShellFlagPrefix(arg string, fullFlag string, minPrefix string) bool {
+	return len(arg) >= len(minPrefix) && len(arg) <= len(fullFlag) && strings.HasPrefix(fullFlag, arg)
+}
+
+func isPowerShellCommandFlag(arg string) bool {
+	lowerArg := strings.ToLower(arg)
+	return lowerArg == "-c" || matchesPowerShellFlagPrefix(lowerArg, "-command", "-com")
+}
+
+func isPowerShellEncodedCommandFlag(arg string) bool {
+	lowerArg := strings.ToLower(arg)
+	return lowerArg == "-enc" || matchesPowerShellFlagPrefix(lowerArg, "-encodedcommand", "-enc")
+}
+
+func decodePowerShellEncodedCommand(encoded string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("invalid PowerShell encoded command: %w", err)
+	}
+	if len(decoded)%2 != 0 {
+		return "", fmt.Errorf("invalid PowerShell encoded command length")
+	}
+
+	utf16Words := make([]uint16, 0, len(decoded)/2)
+	for i := 0; i < len(decoded); i += 2 {
+		utf16Words = append(utf16Words, uint16(decoded[i])|uint16(decoded[i+1])<<8)
+	}
+
+	return string(utf16.Decode(utf16Words)), nil
+}
+
 func unwrapPowerShellCommand(args []string) ([]string, error) {
 	for i, arg := range args {
-		if !strings.EqualFold(arg, "-command") && !strings.EqualFold(arg, "-c") {
-			continue
+		switch {
+		case isPowerShellEncodedCommandFlag(arg):
+			if i+1 >= len(args) {
+				return nil, nil
+			}
+			commandString, err := decodePowerShellEncodedCommand(args[i+1])
+			if err != nil {
+				return nil, err
+			}
+			return parseWrappedCommandString(commandString, "PowerShell encoded")
+		case isPowerShellCommandFlag(arg):
+			if i+1 >= len(args) {
+				return nil, nil
+			}
+			rest := args[i+1:]
+			if len(rest) == 1 {
+				return parseWrappedCommandString(rest[0], "PowerShell")
+			}
+			return rest, nil
 		}
-		if i+1 >= len(args) {
-			return nil, nil
-		}
-		rest := args[i+1:]
-		if len(rest) == 1 {
-			return splitShellArgs(rest[0])
-		}
-		return rest, nil
 	}
 
 	return nil, nil

--- a/lib/files.go
+++ b/lib/files.go
@@ -368,12 +368,12 @@ func matchesPowerShellFlagPrefix(arg string, fullFlag string, minPrefix string) 
 
 func isPowerShellCommandFlag(arg string) bool {
 	lowerArg := strings.ToLower(arg)
-	return lowerArg == "-c" || matchesPowerShellFlagPrefix(lowerArg, "-command", "-com")
+	return lowerArg == "-c" || matchesPowerShellFlagPrefix(lowerArg, "-command", "-co")
 }
 
 func isPowerShellEncodedCommandFlag(arg string) bool {
 	lowerArg := strings.ToLower(arg)
-	return lowerArg == "-enc" || matchesPowerShellFlagPrefix(lowerArg, "-encodedcommand", "-enc")
+	return matchesPowerShellFlagPrefix(lowerArg, "-encodedcommand", "-enc")
 }
 
 func isPowerShellFileFlag(arg string) bool {
@@ -430,20 +430,20 @@ func RunPrechecks(deployment *DeployInfo) (map[string]string, error) {
 		precheck := strings.ReplaceAll(precheck, "$TEMPLATEPATH", deployment.TemplateRelativePath)
 		separated, err := splitShellArgs(precheck)
 		if err != nil {
-			return results, err
+			return results, fmt.Errorf("precheck %q: %w", precheck, err)
 		}
 		if len(separated) == 0 {
-			return results, fmt.Errorf("precheck command is empty or only whitespace: %q", precheck)
+			return results, fmt.Errorf("precheck %q is empty or only whitespace", precheck)
 		}
 		command, args := separated[0], separated[1:]
 		if unsafeCommand, err := findUnsafeWrappedPrecheck(separated); err != nil {
-			return results, err
+			return results, fmt.Errorf("precheck %q: %w", precheck, err)
 		} else if unsafeCommand != "" {
-			return results, fmt.Errorf("unsafe command '%v' detected", unsafeCommand)
+			return results, fmt.Errorf("precheck %q: unsafe command %q detected", precheck, unsafeCommand)
 		}
 		binary, lookErr := exec.LookPath(command)
 		if lookErr != nil {
-			return results, fmt.Errorf("command '%v' cannot be found", command)
+			return results, fmt.Errorf("precheck %q: command %q cannot be found", precheck, command)
 		}
 		cmd := exec.Command(binary, args...)
 		var out bytes.Buffer

--- a/lib/files.go
+++ b/lib/files.go
@@ -207,6 +207,8 @@ func unwrapEnvCommand(args []string) ([]string, error) {
 				return nil, fmt.Errorf("env wrapper missing command after %q", arg)
 			}
 			return splitShellArgs(args[i+1])
+		case strings.HasPrefix(arg, "--split-string="):
+			return splitShellArgs(strings.TrimPrefix(arg, "--split-string="))
 		case arg == "-u" || arg == "--unset" || arg == "-C" || arg == "--chdir" || arg == "-a" || arg == "--argv0":
 			i += 2
 		case strings.HasPrefix(arg, "--unset=") || strings.HasPrefix(arg, "--chdir=") || strings.HasPrefix(arg, "--argv0="):
@@ -273,7 +275,7 @@ func unwrapShellShortOptions(arg string, args []string, index *int) ([]string, e
 			if pos+1 < len(shortOpts) {
 				return nil, nil
 			}
-			*index++
+			(*index)++
 			return nil, nil
 		}
 	}
@@ -323,11 +325,7 @@ func unwrapCmdCommand(args []string) ([]string, error) {
 		if i+1 >= len(args) {
 			return nil, nil
 		}
-		rest := args[i+1:]
-		if len(rest) == 1 {
-			return splitShellArgs(rest[0])
-		}
-		return rest, nil
+		return parseWrappedCommandString(strings.Join(args[i+1:], " "), "cmd")
 	}
 
 	return nil, nil
@@ -387,11 +385,7 @@ func unwrapPowerShellCommand(args []string) ([]string, error) {
 			if i+1 >= len(args) {
 				return nil, nil
 			}
-			rest := args[i+1:]
-			if len(rest) == 1 {
-				return parseWrappedCommandString(rest[0], "PowerShell")
-			}
-			return rest, nil
+			return parseWrappedCommandString(strings.Join(args[i+1:], " "), "PowerShell")
 		}
 	}
 

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -390,6 +390,8 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"env wrapper", "env rm --help", "unsafe command"},
 		{"env with assignment", "env SAFE=1 rm --help", "unsafe command"},
 		{"env split string", `env -S 'rm --help'`, "unsafe command"},
+		{"env argv0 flag", "env -a safe-name rm --help", "unsafe command"},
+		{"env argv0 long flag", "env --argv0=safe-name rm --help", "unsafe command"},
 		{"env -S nested shell", `env -S 'sh -c "rm -rf test/path.yaml"'`, "unsafe command"},
 		{"env wrapping shell", `env sh -c 'rm -rf test/path.yaml'`, "unsafe command"},
 		{"shell -c wrapper", `sh -c 'rm -rf test/path.yaml'`, "unsafe command"},
@@ -402,6 +404,8 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"powershell wrapper", `pwsh -Command "kill 1234"`, "unsafe command"},
 		{"powershell command prefix", `pwsh -Com "rm -rf ."`, "unsafe command"},
 		{"powershell encoded command", "pwsh -enc " + encodePowerShellCommand(t, "rm -rf ."), "unsafe command"},
+		{"powershell file wrapper", `pwsh -File dangerous.ps1`, "cannot be safely unwrapped"},
+		{"powershell file alias", `pwsh -f dangerous.ps1`, "cannot be safely unwrapped"},
 	}
 
 	for _, tc := range cases {

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -390,6 +390,7 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"env wrapper", "env rm --help", "unsafe command"},
 		{"env with assignment", "env SAFE=1 rm --help", "unsafe command"},
 		{"env split string", `env -S 'rm --help'`, "unsafe command"},
+		{"env split string equals", `env --split-string='rm --help'`, "unsafe command"},
 		{"env argv0 flag", "env -a safe-name rm --help", "unsafe command"},
 		{"env argv0 long flag", "env --argv0=safe-name rm --help", "unsafe command"},
 		{"env -S nested shell", `env -S 'sh -c "rm -rf test/path.yaml"'`, "unsafe command"},
@@ -402,8 +403,12 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"bash inline -o before -c", `bash -onoclobber -c 'rm -rf test/path.yaml'`, "unsafe command"},
 		{"deeply nested wrappers", `sh -c 'bash -c "env rm --help"'`, "unsafe command"},
 		{"cmd wrapper", `cmd /c del important.txt`, "unsafe command"},
+		{"cmd keep wrapper", `cmd /k del important.txt`, "unsafe command"},
+		{"cmd flag before c", `cmd /q /c del important.txt`, "unsafe command"},
+		{"cmd operator without whitespace is rejected", `cmd /c echo ok&del important.txt`, "cannot be safely unwrapped"},
 		{"powershell wrapper", `pwsh -Command "kill 1234"`, "unsafe command"},
 		{"powershell command prefix", `pwsh -Com "rm -rf ."`, "unsafe command"},
+		{"powershell multi arg sequence is rejected", `pwsh -Command echo ok; rm -rf .`, "cannot be safely unwrapped"},
 		{"powershell encoded command", "pwsh -enc " + encodePowerShellCommand(t, "rm -rf ."), "unsafe command"},
 		{"powershell file wrapper", `pwsh -File dangerous.ps1`, "cannot be safely unwrapped"},
 		{"powershell file alias", `pwsh -f dangerous.ps1`, "cannot be safely unwrapped"},
@@ -436,6 +441,7 @@ func TestFindUnsafeWrappedPrecheckSafeWrapper(t *testing.T) {
 		{"env wrapper", `env SAFE=1 test hello = hello`},
 		{"shell wrapper", `sh -c "echo hello"`},
 		{"powershell command", `pwsh -Command "echo hello"`},
+		{"powershell multi arg command", `pwsh -Command Write-Output hello`},
 	}
 
 	for _, tc := range cases {

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -391,6 +391,7 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"env with assignment", "env SAFE=1 rm --help", "unsafe command"},
 		{"env split string", `env -S 'rm --help'`, "unsafe command"},
 		{"env split string equals", `env --split-string='rm --help'`, "unsafe command"},
+		{"env split string sequence is rejected", `env -S 'echo ok; rm -rf test/path.yaml'`, "cannot be safely unwrapped"},
 		{"env argv0 flag", "env -a safe-name rm --help", "unsafe command"},
 		{"env argv0 long flag", "env --argv0=safe-name rm --help", "unsafe command"},
 		{"env -S nested shell", `env -S 'sh -c "rm -rf test/path.yaml"'`, "unsafe command"},
@@ -406,8 +407,10 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"cmd keep wrapper", `cmd /k del important.txt`, "unsafe command"},
 		{"cmd flag before c", `cmd /q /c del important.txt`, "unsafe command"},
 		{"cmd operator without whitespace is rejected", `cmd /c echo ok&del important.txt`, "cannot be safely unwrapped"},
+		{"cmd backslash operator is rejected", `cmd /c "echo ok\\&del important.txt"`, "cannot be safely unwrapped"},
 		{"powershell wrapper", `pwsh -Command "kill 1234"`, "unsafe command"},
 		{"powershell command prefix", `pwsh -Com "rm -rf ."`, "unsafe command"},
+		{"powershell backslash operator is rejected", `pwsh -Command "echo ok\\; rm -rf ."`, "cannot be safely unwrapped"},
 		{"powershell multi arg sequence is rejected", `pwsh -Command echo ok; rm -rf .`, "cannot be safely unwrapped"},
 		{"powershell encoded command", "pwsh -enc " + encodePowerShellCommand(t, "rm -rf ."), "unsafe command"},
 		{"powershell file wrapper", `pwsh -File dangerous.ps1`, "cannot be safely unwrapped"},
@@ -440,6 +443,7 @@ func TestFindUnsafeWrappedPrecheckSafeWrapper(t *testing.T) {
 	}{
 		{"env wrapper", `env SAFE=1 test hello = hello`},
 		{"shell wrapper", `sh -c "echo hello"`},
+		{"cmd wrapper", `cmd /c echo hello`},
 		{"powershell command", `pwsh -Command "echo hello"`},
 		{"powershell multi arg command", `pwsh -Command Write-Output hello`},
 	}

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -396,6 +396,7 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"env wrapping shell", `env sh -c 'rm -rf test/path.yaml'`, "unsafe command"},
 		{"shell -c wrapper", `sh -c 'rm -rf test/path.yaml'`, "unsafe command"},
 		{"shell sequence is rejected", `sh -c 'echo ok; rm -rf test/path.yaml'`, "cannot be safely unwrapped"},
+		{"shell backtick substitution is rejected", "sh -c '`rm -rf test/path.yaml`'", "cannot be safely unwrapped"},
 		{"bash -lc wrapper", `bash -lc 'kill -9 1234'`, "unsafe command"},
 		{"bash option before -c", `bash -o pipefail -c 'rm -rf test/path.yaml'`, "unsafe command"},
 		{"bash inline -o before -c", `bash -onoclobber -c 'rm -rf test/path.yaml'`, "unsafe command"},

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -1,12 +1,14 @@
 package lib
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/spf13/viper"
 )
@@ -332,9 +334,11 @@ func TestRunPrechecksUnsafeCommandWithPath(t *testing.T) {
 		command string
 	}{
 		{"absolute path rm", "/bin/rm --help"},
+		{"absolute path rm.exe", "/bin/rm.exe --help"},
 		{"absolute path del", "/usr/bin/del --help"},
 		{"absolute path kill", "/bin/kill --help"},
 		{"relative path rm", "./rm --help"},
+		{"relative path kill.cmd", "./kill.cmd --help"},
 		{"relative path with dir", "../bin/rm --help"},
 		{"bare command rm", "rm --help"},
 		{"bare command del", "del --help"},
@@ -357,6 +361,18 @@ func TestRunPrechecksUnsafeCommandWithPath(t *testing.T) {
 	}
 }
 
+func encodePowerShellCommand(t *testing.T, command string) string {
+	t.Helper()
+
+	utf16Words := utf16.Encode([]rune(command))
+	bytes := make([]byte, 0, len(utf16Words)*2)
+	for _, word := range utf16Words {
+		bytes = append(bytes, byte(word), byte(word>>8))
+	}
+
+	return base64.StdEncoding.EncodeToString(bytes)
+}
+
 func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 	// Regression test for T-1071: RunPrechecks must reject unsafe commands
 	// even when a wrapper executable forwards to them.
@@ -367,18 +383,25 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 	}
 
 	cases := []struct {
-		name    string
-		command string
+		name            string
+		command         string
+		wantErrContains string
 	}{
-		{"env wrapper", "env rm --help"},
-		{"env with assignment", "env SAFE=1 rm --help"},
-		{"env split string", `env -S 'rm --help'`},
-		{"env wrapping shell", `env sh -c 'rm -rf test/path.yaml'`},
-		{"shell -c wrapper", `sh -c 'rm -rf test/path.yaml'`},
-		{"bash -lc wrapper", `bash -lc 'kill -9 1234'`},
-		{"bash option before -c", `bash -o pipefail -c 'rm -rf test/path.yaml'`},
-		{"cmd wrapper", `cmd /c del important.txt`},
-		{"powershell wrapper", `pwsh -Command "kill 1234"`},
+		{"env wrapper", "env rm --help", "unsafe command"},
+		{"env with assignment", "env SAFE=1 rm --help", "unsafe command"},
+		{"env split string", `env -S 'rm --help'`, "unsafe command"},
+		{"env -S nested shell", `env -S 'sh -c "rm -rf test/path.yaml"'`, "unsafe command"},
+		{"env wrapping shell", `env sh -c 'rm -rf test/path.yaml'`, "unsafe command"},
+		{"shell -c wrapper", `sh -c 'rm -rf test/path.yaml'`, "unsafe command"},
+		{"shell sequence is rejected", `sh -c 'echo ok; rm -rf test/path.yaml'`, "cannot be safely unwrapped"},
+		{"bash -lc wrapper", `bash -lc 'kill -9 1234'`, "unsafe command"},
+		{"bash option before -c", `bash -o pipefail -c 'rm -rf test/path.yaml'`, "unsafe command"},
+		{"bash inline -o before -c", `bash -onoclobber -c 'rm -rf test/path.yaml'`, "unsafe command"},
+		{"deeply nested wrappers", `sh -c 'bash -c "env rm --help"'`, "unsafe command"},
+		{"cmd wrapper", `cmd /c del important.txt`, "unsafe command"},
+		{"powershell wrapper", `pwsh -Command "kill 1234"`, "unsafe command"},
+		{"powershell command prefix", `pwsh -Com "rm -rf ."`, "unsafe command"},
+		{"powershell encoded command", "pwsh -enc " + encodePowerShellCommand(t, "rm -rf ."), "unsafe command"},
 	}
 
 	for _, tc := range cases {
@@ -388,11 +411,40 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 			if err == nil {
 				t.Fatalf("RunPrechecks(%q) should detect unsafe wrapped command, got results: %v", tc.command, results)
 			}
-			if !strings.Contains(err.Error(), "unsafe command") {
-				t.Fatalf("RunPrechecks(%q) error should mention 'unsafe command', got: %v", tc.command, err)
+			if !strings.Contains(err.Error(), tc.wantErrContains) {
+				t.Fatalf("RunPrechecks(%q) error should mention %q, got: %v", tc.command, tc.wantErrContains, err)
 			}
 			if len(results) > 0 {
 				t.Fatalf("RunPrechecks(%q) should not return results for unsafe wrapped command, got: %v", tc.command, results)
+			}
+		})
+	}
+}
+
+func TestFindUnsafeWrappedPrecheckSafeWrapper(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{"env wrapper", `env SAFE=1 test hello = hello`},
+		{"shell wrapper", `sh -c "echo hello"`},
+		{"powershell command", `pwsh -Command "echo hello"`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := splitShellArgs(tc.command)
+			if err != nil {
+				t.Fatalf("splitShellArgs(%q): %v", tc.command, err)
+			}
+			unsafeCommand, err := findUnsafeWrappedPrecheck(args)
+			if err != nil {
+				t.Fatalf("findUnsafeWrappedPrecheck(%q) unexpected error: %v", tc.command, err)
+			}
+			if unsafeCommand != "" {
+				t.Fatalf("findUnsafeWrappedPrecheck(%q) = %q, want no unsafe command", tc.command, unsafeCommand)
 			}
 		})
 	}

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -357,6 +357,47 @@ func TestRunPrechecksUnsafeCommandWithPath(t *testing.T) {
 	}
 }
 
+func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
+	// Regression test for T-1071: RunPrechecks must reject unsafe commands
+	// even when a wrapper executable forwards to them.
+	t.Cleanup(viper.Reset)
+
+	deployment := &DeployInfo{
+		TemplateRelativePath: "test/path.yaml",
+	}
+
+	cases := []struct {
+		name    string
+		command string
+	}{
+		{"env wrapper", "env rm --help"},
+		{"env with assignment", "env SAFE=1 rm --help"},
+		{"env split string", `env -S 'rm --help'`},
+		{"env wrapping shell", `env sh -c 'rm -rf test/path.yaml'`},
+		{"shell -c wrapper", `sh -c 'rm -rf test/path.yaml'`},
+		{"bash -lc wrapper", `bash -lc 'kill -9 1234'`},
+		{"bash option before -c", `bash -o pipefail -c 'rm -rf test/path.yaml'`},
+		{"cmd wrapper", `cmd /c del important.txt`},
+		{"powershell wrapper", `pwsh -Command "kill 1234"`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			viper.Set("templates.prechecks", []string{tc.command})
+			results, err := RunPrechecks(deployment)
+			if err == nil {
+				t.Fatalf("RunPrechecks(%q) should detect unsafe wrapped command, got results: %v", tc.command, results)
+			}
+			if !strings.Contains(err.Error(), "unsafe command") {
+				t.Fatalf("RunPrechecks(%q) error should mention 'unsafe command', got: %v", tc.command, err)
+			}
+			if len(results) > 0 {
+				t.Fatalf("RunPrechecks(%q) should not return results for unsafe wrapped command, got: %v", tc.command, results)
+			}
+		})
+	}
+}
+
 func TestRunPrechecksEmptyCommand(t *testing.T) {
 	t.Cleanup(viper.Reset)
 

--- a/lib/files_test.go
+++ b/lib/files_test.go
@@ -365,12 +365,12 @@ func encodePowerShellCommand(t *testing.T, command string) string {
 	t.Helper()
 
 	utf16Words := utf16.Encode([]rune(command))
-	bytes := make([]byte, 0, len(utf16Words)*2)
+	buf := make([]byte, 0, len(utf16Words)*2)
 	for _, word := range utf16Words {
-		bytes = append(bytes, byte(word), byte(word>>8))
+		buf = append(buf, byte(word), byte(word>>8))
 	}
 
-	return base64.StdEncoding.EncodeToString(bytes)
+	return base64.StdEncoding.EncodeToString(buf)
 }
 
 func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
@@ -409,6 +409,7 @@ func TestRunPrechecksUnsafeWrappedCommand(t *testing.T) {
 		{"cmd operator without whitespace is rejected", `cmd /c echo ok&del important.txt`, "cannot be safely unwrapped"},
 		{"cmd backslash operator is rejected", `cmd /c "echo ok\\&del important.txt"`, "cannot be safely unwrapped"},
 		{"powershell wrapper", `pwsh -Command "kill 1234"`, "unsafe command"},
+		{"powershell short command prefix", `pwsh -co "rm -rf ."`, "unsafe command"},
 		{"powershell command prefix", `pwsh -Com "rm -rf ."`, "unsafe command"},
 		{"powershell backslash operator is rejected", `pwsh -Command "echo ok\\; rm -rf ."`, "cannot be safely unwrapped"},
 		{"powershell multi arg sequence is rejected", `pwsh -Command echo ok; rm -rf .`, "cannot be safely unwrapped"},

--- a/specs/bugfixes/block-wrapped-unsafe-precheck-commands/report.md
+++ b/specs/bugfixes/block-wrapped-unsafe-precheck-commands/report.md
@@ -40,7 +40,7 @@ The precheck safety guard inspects only the first parsed executable name. That w
 - `lib/files.go` — Rejects shell/PowerShell command strings that contain control operators and therefore cannot be safely reduced to a single argv vector during precheck validation.
 - `lib/files_test.go` — Added regression coverage for `env`, `env -S`, nested wrappers, shell `-c`/`-lc`, `cmd /c`, PowerShell command/encoded-command wrappers, Windows executable suffixes, and safe wrapper cases.
 
-**Approach rationale:** The fix keeps the current deny-list design but applies it to the command that will actually execute, not just the outer wrapper binary. Recursive unwrapping is still a small, local change, but it now errs on the side of safety when wrapper command strings become too shell-like to inspect reliably.
+**Approach rationale:** The fix keeps the current deny-list design but applies it to the command that will actually execute, not just the outer wrapper binary. Recursive unwrapping is still a small, local change, but it now errs on the side of safety when wrapper command strings become too shell-like to inspect reliably. The wrapper coverage is intentionally best-effort rather than exhaustive, so an allowlist remains the stronger long-term hardening option.
 
 **Alternatives considered:**
 - Allowlist precheck executables entirely — stronger but broader in scope than this bugfix
@@ -76,6 +76,7 @@ The precheck safety guard inspects only the first parsed executable name. That w
 **Recommendations to avoid similar bugs:**
 - Treat wrapper executables as delegated execution and inspect the nested command they will run
 - Add regression tests whenever precheck validation logic changes
+- Document wrapper-inspection limits whenever the deny-list expands so maintainers do not assume it is exhaustive
 - Consider an allowlist for precheck executables as a future hardening step
 
 ## Related

--- a/specs/bugfixes/block-wrapped-unsafe-precheck-commands/report.md
+++ b/specs/bugfixes/block-wrapped-unsafe-precheck-commands/report.md
@@ -35,10 +35,12 @@ The precheck safety guard inspects only the first parsed executable name. That w
 
 **Changes made:**
 - `lib/files.go` — Added recursive wrapped-command inspection so `RunPrechecks` denies blocked commands when they are delegated through `env`, POSIX shells (`sh`, `bash`, `zsh`, `dash`, `ksh`, `ash`), `cmd /c`, and PowerShell command wrappers.
-- `lib/files.go` — Taught shell-wrapper parsing to keep scanning past option/value pairs such as `bash -o pipefail -c ...` before evaluating the nested command string.
-- `lib/files_test.go` — Added regression coverage for `env`, `env -S`, nested `env sh -c`, shell `-c`/`-lc`, `cmd /c`, and PowerShell wrapper bypasses.
+- `lib/files.go` — Tightened shell option parsing so only real `-c` flag combinations are treated as command wrappers, while option/value pairs such as `bash -o pipefail -c ...` and `bash -onoclobber -c ...` continue to work.
+- `lib/files.go` — Normalized Windows-style executable suffixes (`.exe`, `.bat`, `.cmd`) and added PowerShell `-EncodedCommand` detection.
+- `lib/files.go` — Rejects shell/PowerShell command strings that contain control operators and therefore cannot be safely reduced to a single argv vector during precheck validation.
+- `lib/files_test.go` — Added regression coverage for `env`, `env -S`, nested wrappers, shell `-c`/`-lc`, `cmd /c`, PowerShell command/encoded-command wrappers, Windows executable suffixes, and safe wrapper cases.
 
-**Approach rationale:** The fix keeps the current deny-list design but applies it to the command that will actually execute, not just the outer wrapper binary. Recursive unwrapping is a small, local change that closes the reported bypass without redesigning the whole precheck feature.
+**Approach rationale:** The fix keeps the current deny-list design but applies it to the command that will actually execute, not just the outer wrapper binary. Recursive unwrapping is still a small, local change, but it now errs on the side of safety when wrapper command strings become too shell-like to inspect reliably.
 
 **Alternatives considered:**
 - Allowlist precheck executables entirely — stronger but broader in scope than this bugfix
@@ -48,7 +50,7 @@ The precheck safety guard inspects only the first parsed executable name. That w
 **Test file:** `lib/files_test.go`
 **Test name:** `TestRunPrechecksUnsafeWrappedCommand`
 
-**What it verifies:** That unsafe commands are rejected even when invoked through wrapper executables such as `env`, `sh -c`, or `bash -lc`.
+**What it verifies:** That unsafe commands are rejected even when invoked through wrapper executables such as `env`, `sh -c`, `bash -lc`, `cmd /c`, PowerShell command strings, or PowerShell encoded commands, while safe wrapped commands remain allowed.
 
 **Run command:** `go test ./lib -run TestRunPrechecksUnsafeWrappedCommand -v`
 

--- a/specs/bugfixes/block-wrapped-unsafe-precheck-commands/report.md
+++ b/specs/bugfixes/block-wrapped-unsafe-precheck-commands/report.md
@@ -1,0 +1,81 @@
+# Bugfix Report: Block Wrapped Unsafe Precheck Commands
+
+**Date:** 2026-04-28
+**Status:** Fixed
+**Ticket:** T-1071
+
+## Description of the Issue
+
+`RunPrechecks` only deny-listed the first executable token returned by `splitShellArgs`, so wrapper executables such as `env` or `sh -c` could still invoke blocked commands like `rm`, `del`, or `kill`.
+
+**Reproduction steps:**
+1. Configure `templates.prechecks: ["env rm --help"]` or `templates.prechecks: ["sh -c 'rm -rf template.yaml'"]`
+2. Run a deployment that triggers prechecks
+3. The wrapped unsafe command executes instead of being rejected before `exec.Command`
+
+**Impact:** High severity — a misconfigured or malicious precheck can still execute destructive commands by placing them behind a wrapper executable.
+
+## Investigation Summary
+
+- **Symptoms examined:** Direct `rm` commands were blocked, but wrapper forms such as `env rm --help`, `env sh -c 'rm -rf ...'`, and `sh -c 'rm -rf ...'` still ran.
+- **Code inspected:** `lib/files.go` (`RunPrechecks` and `splitShellArgs`) and `lib/files_test.go`
+- **Hypotheses tested:** Confirmed with failing regression tests that the deny-list only validates `separated[0]`, so it misses delegated commands embedded behind wrappers.
+
+## Discovered Root Cause
+
+The precheck safety guard inspects only the first parsed executable name. That works for direct invocations, but wrapper executables forward execution to a second command string or nested executable, which `RunPrechecks` never inspects.
+
+**Defect type:** Incomplete validation of delegated execution
+
+**Why it occurred:** The original validation assumed the executable token was always the command that would ultimately run. Wrapper semantics (`env`, `sh -c`, etc.) violate that assumption.
+
+**Contributing factors:** Existing regression coverage only covered direct command names and path-prefixed variants, not wrapped execution paths.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `lib/files.go` — Added recursive wrapped-command inspection so `RunPrechecks` denies blocked commands when they are delegated through `env`, POSIX shells (`sh`, `bash`, `zsh`, `dash`, `ksh`, `ash`), `cmd /c`, and PowerShell command wrappers.
+- `lib/files.go` — Taught shell-wrapper parsing to keep scanning past option/value pairs such as `bash -o pipefail -c ...` before evaluating the nested command string.
+- `lib/files_test.go` — Added regression coverage for `env`, `env -S`, nested `env sh -c`, shell `-c`/`-lc`, `cmd /c`, and PowerShell wrapper bypasses.
+
+**Approach rationale:** The fix keeps the current deny-list design but applies it to the command that will actually execute, not just the outer wrapper binary. Recursive unwrapping is a small, local change that closes the reported bypass without redesigning the whole precheck feature.
+
+**Alternatives considered:**
+- Allowlist precheck executables entirely — stronger but broader in scope than this bugfix
+
+## Regression Test
+
+**Test file:** `lib/files_test.go`
+**Test name:** `TestRunPrechecksUnsafeWrappedCommand`
+
+**What it verifies:** That unsafe commands are rejected even when invoked through wrapper executables such as `env`, `sh -c`, or `bash -lc`.
+
+**Run command:** `go test ./lib -run TestRunPrechecksUnsafeWrappedCommand -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `lib/files.go` | Harden wrapped-command validation before executing prechecks |
+| `lib/files_test.go` | Add regression coverage for wrapped unsafe commands |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes (`go test ./lib -run TestRunPrechecksUnsafeWrappedCommand -v`)
+- [x] Full test suite passes (`go test ./... -v`)
+- [x] Linters/validators pass (`golangci-lint run`)
+
+**Manual verification:**
+- Not needed beyond automated coverage; the failing bypass cases are fully exercised by unit tests before command execution.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Treat wrapper executables as delegated execution and inspect the nested command they will run
+- Add regression tests whenever precheck validation logic changes
+- Consider an allowlist for precheck executables as a future hardening step
+
+## Related
+
+- Transit ticket T-1071


### PR DESCRIPTION
## Summary
- block wrapped unsafe precheck invocations before exec.Command runs
- inspect env, shell, cmd, and PowerShell wrappers recursively so the real delegated command is validated
- add regression coverage and a bugfix report for the wrapper bypass cases

## Root Cause
RunPrechecks only deny-listed the first executable token returned by splitShellArgs, so wrappers like env rm --help or sh -c "rm -rf ..." bypassed the rm/del/kill guard.

## Testing
- go test ./lib -run TestRunPrechecksUnsafeWrappedCommand -v
- go test ./... -v
- golangci-lint run

## Report
- specs/bugfixes/block-wrapped-unsafe-precheck-commands/report.md