### PR TITLE
[bug] Fix T-1072: Validate Lambda stack-id before report generation

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,11 +36,14 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ArjenSchwarz/fog/cmd"
 	"github.com/aws/aws-lambda-go/lambda"
 )
+
+var generateReportFromLambda = cmd.GenerateReportFromLambda
 
 // EventBridgeMessage represents an AWS EventBridge message for CloudFormation stack events.
 //
@@ -106,7 +109,11 @@ func HandleRequest(message EventBridgeMessage) error {
 	if format == "" {
 		return fmt.Errorf("required environment variable ReportOutputFormat is not set")
 	}
+	stackID := strings.TrimSpace(message.Detail.StackId)
+	if stackID == "" {
+		return fmt.Errorf("required EventBridge detail.stack-id is not set")
+	}
 	filename := os.Getenv("ReportNamePattern")
 	timezone := os.Getenv("ReportTimezone")
-	return cmd.GenerateReportFromLambda(message.Detail.StackId, s3bucket, filename, format, timezone)
+	return generateReportFromLambda(stackID, s3bucket, filename, format, timezone)
 }

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 )
 
+// generateReportFromLambda provides a test seam for HandleRequest.
+// Tests that replace this variable must not run in parallel.
 var generateReportFromLambda = cmd.GenerateReportFromLambda
 
 // EventBridgeMessage represents an AWS EventBridge message for CloudFormation stack events.
@@ -111,7 +113,7 @@ func HandleRequest(message EventBridgeMessage) error {
 	}
 	stackID := strings.TrimSpace(message.Detail.StackId)
 	if stackID == "" {
-		return fmt.Errorf("required EventBridge detail.stack-id is not set")
+		return fmt.Errorf("required EventBridge detail.stack-id is missing or blank")
 	}
 	filename := os.Getenv("ReportNamePattern")
 	timezone := os.Getenv("ReportTimezone")

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -44,5 +45,64 @@ func TestHandleRequestReturnsErrorOnMissingFormat(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "ReportOutputFormat") {
 		t.Errorf("error should mention ReportOutputFormat, got: %v", err)
+	}
+}
+
+// TestHandleRequestReturnsErrorOnMissingStackID verifies that invalid EventBridge
+// payloads are rejected before report generation starts.
+func TestHandleRequestReturnsErrorOnMissingStackID(t *testing.T) {
+	t.Setenv("ReportS3Bucket", "my-bucket")
+	t.Setenv("ReportOutputFormat", "markdown")
+	t.Setenv("ReportNamePattern", "report-$STACKNAME.md")
+	t.Setenv("ReportTimezone", "UTC")
+
+	originalGenerateReportFromLambda := generateReportFromLambda
+	t.Cleanup(func() {
+		generateReportFromLambda = originalGenerateReportFromLambda
+	})
+
+	var called bool
+	generateReportFromLambda = func(stackname string, bucketname string, outputfilename string, outputformat string, timezone string) error {
+		called = true
+		return errors.New("report generation should not be called")
+	}
+
+	err := HandleRequest(EventBridgeMessage{})
+	if err == nil {
+		t.Fatal("HandleRequest should return an error when detail.stack-id is empty")
+	}
+	if !strings.Contains(err.Error(), "stack-id") {
+		t.Errorf("error should mention stack-id, got: %v", err)
+	}
+	if called {
+		t.Fatal("HandleRequest should fail before invoking report generation")
+	}
+}
+
+func TestHandleRequestPassesTrimmedStackIDToReportGeneration(t *testing.T) {
+	t.Setenv("ReportS3Bucket", "my-bucket")
+	t.Setenv("ReportOutputFormat", "markdown")
+	t.Setenv("ReportNamePattern", "report-$STACKNAME.md")
+	t.Setenv("ReportTimezone", "UTC")
+
+	originalGenerateReportFromLambda := generateReportFromLambda
+	t.Cleanup(func() {
+		generateReportFromLambda = originalGenerateReportFromLambda
+	})
+
+	var receivedStackID string
+	generateReportFromLambda = func(stackname string, bucketname string, outputfilename string, outputformat string, timezone string) error {
+		receivedStackID = stackname
+		return nil
+	}
+
+	msg := EventBridgeMessage{}
+	msg.Detail.StackId = "  arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/abc  "
+
+	if err := HandleRequest(msg); err != nil {
+		t.Fatalf("HandleRequest returned unexpected error: %v", err)
+	}
+	if receivedStackID != "arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/abc" {
+		t.Fatalf("expected trimmed stack-id to be forwarded, got %q", receivedStackID)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -79,6 +79,38 @@ func TestHandleRequestReturnsErrorOnMissingStackID(t *testing.T) {
 	}
 }
 
+func TestHandleRequestReturnsErrorOnWhitespaceOnlyStackID(t *testing.T) {
+	t.Setenv("ReportS3Bucket", "my-bucket")
+	t.Setenv("ReportOutputFormat", "markdown")
+	t.Setenv("ReportNamePattern", "report-$STACKNAME.md")
+	t.Setenv("ReportTimezone", "UTC")
+
+	originalGenerateReportFromLambda := generateReportFromLambda
+	t.Cleanup(func() {
+		generateReportFromLambda = originalGenerateReportFromLambda
+	})
+
+	var called bool
+	generateReportFromLambda = func(stackname string, bucketname string, outputfilename string, outputformat string, timezone string) error {
+		called = true
+		return errors.New("report generation should not be called")
+	}
+
+	msg := EventBridgeMessage{}
+	msg.Detail.StackId = "   "
+
+	err := HandleRequest(msg)
+	if err == nil {
+		t.Fatal("HandleRequest should return an error when detail.stack-id is blank after trimming")
+	}
+	if !strings.Contains(err.Error(), "missing or blank") {
+		t.Errorf("error should mention missing or blank stack-id, got: %v", err)
+	}
+	if called {
+		t.Fatal("HandleRequest should fail before invoking report generation")
+	}
+}
+
 func TestHandleRequestPassesTrimmedStackIDToReportGeneration(t *testing.T) {
 	t.Setenv("ReportS3Bucket", "my-bucket")
 	t.Setenv("ReportOutputFormat", "markdown")

--- a/specs/bugfixes/validate-lambda-stack-id-before-report-generation/report.md
+++ b/specs/bugfixes/validate-lambda-stack-id-before-report-generation/report.md
@@ -1,0 +1,89 @@
+# Bugfix Report: Validate Lambda stack-id before report generation
+
+**Date:** 2026-04-28
+**Status:** Fixed
+
+## Description of the Issue
+
+The Lambda entrypoint accepted EventBridge payloads with an empty or missing `detail.stack-id`.
+When that happened, `HandleRequest` passed the empty value into report generation, allowing downstream
+code to treat the request like an account-wide `all-stacks` report instead of rejecting the invalid event.
+
+**Reproduction steps:**
+1. Configure the Lambda environment with `ReportS3Bucket` and `ReportOutputFormat`.
+2. Invoke `HandleRequest` with an EventBridge message whose `detail.stack-id` is empty or omitted.
+3. Observe that the handler forwards the empty stack identifier instead of failing fast.
+
+**Impact:** Invalid CloudFormation events can trigger the wrong report scope and produce an unintended account-wide report.
+
+## Investigation Summary
+
+Reviewed the Lambda handler path and the Lambda-specific report entrypoint to trace how `detail.stack-id`
+flows through report generation.
+
+- **Symptoms examined:** Empty `detail.stack-id` values did not cause handler validation failures.
+- **Code inspected:** `main.go`, `main_test.go`, and `cmd/report.go`.
+- **Hypotheses tested:** Confirmed that handler validation existed for required environment variables but not for the EventBridge stack identifier.
+
+## Discovered Root Cause
+
+`HandleRequest` validated Lambda configuration but trusted the incoming EventBridge payload. An empty
+`detail.stack-id` therefore reached `GenerateReportFromLambda`, which uses the provided value as the report
+target without its own guard in this call path.
+
+**Defect type:** Missing validation
+
+**Why it occurred:** Handler-side validation was added for environment variables, but the required event payload field was overlooked.
+
+**Contributing factors:** The handler directly called report generation, making it hard to regression-test whether invalid events were rejected before any downstream work started.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `main.go:46` - Introduced an injectable `generateReportFromLambda` function reference so handler behaviour can be isolated in unit tests.
+- `main.go:103` - Added `detail.stack-id` validation with whitespace trimming and fail-fast error handling before report generation starts.
+- `main_test.go:51` - Added a regression test proving empty EventBridge stack identifiers return an error and never invoke report generation.
+- `main_test.go:82` - Added a success-path test confirming valid stack identifiers are trimmed and forwarded to report generation.
+
+**Approach rationale:** Validate the event payload at the Lambda boundary, because that is the narrowest point where malformed EventBridge data can be rejected before any AWS-facing report logic runs. The small injection hook keeps the tests fast and deterministic without changing the production code path.
+
+**Alternatives considered:**
+- Add validation inside `cmd.GenerateReportFromLambda` - not chosen because the bug specifically originates in the Lambda handler path and should fail before invoking report generation.
+
+## Regression Test
+
+**Test file:** `main_test.go`
+**Test name:** `TestHandleRequestReturnsErrorOnMissingStackID`
+
+**What it verifies:** `HandleRequest` rejects an EventBridge payload with an empty `detail.stack-id` before report generation is invoked.
+
+**Run command:** `go test ./... -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `main.go` | Added stack-id validation and a test seam for the Lambda report call |
+| `main_test.go` | Added regression and success-path coverage for Lambda stack-id handling |
+| `specs/bugfixes/validate-lambda-stack-id-before-report-generation/report.md` | Documented investigation, fix, and verification |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- `go build -o fog` completed successfully to confirm the binary still builds.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Validate required EventBridge fields at the Lambda boundary before invoking business logic.
+- Keep handler dependencies injectable so fast-fail behaviour can be regression-tested without AWS calls.
+- Add regression tests for malformed event payloads whenever Lambda event schemas change.
+
+## Related
+
+- Transit ticket `T-1072`

--- a/specs/bugfixes/validate-lambda-stack-id-before-report-generation/report.md
+++ b/specs/bugfixes/validate-lambda-stack-id-before-report-generation/report.md
@@ -5,13 +5,13 @@
 
 ## Description of the Issue
 
-The Lambda entrypoint accepted EventBridge payloads with an empty or missing `detail.stack-id`.
+The Lambda entrypoint accepted EventBridge payloads with an empty, missing, or whitespace-only `detail.stack-id`.
 When that happened, `HandleRequest` passed the empty value into report generation, allowing downstream
 code to treat the request like an account-wide `all-stacks` report instead of rejecting the invalid event.
 
 **Reproduction steps:**
 1. Configure the Lambda environment with `ReportS3Bucket` and `ReportOutputFormat`.
-2. Invoke `HandleRequest` with an EventBridge message whose `detail.stack-id` is empty or omitted.
+2. Invoke `HandleRequest` with an EventBridge message whose `detail.stack-id` is empty, omitted, or only whitespace.
 3. Observe that the handler forwards the empty stack identifier instead of failing fast.
 
 **Impact:** Invalid CloudFormation events can trigger the wrong report scope and produce an unintended account-wide report.
@@ -42,8 +42,8 @@ target without its own guard in this call path.
 **Changes made:**
 - `main.go:46` - Introduced an injectable `generateReportFromLambda` function reference so handler behaviour can be isolated in unit tests.
 - `main.go:103` - Added `detail.stack-id` validation with whitespace trimming and fail-fast error handling before report generation starts.
-- `main_test.go:51` - Added a regression test proving empty EventBridge stack identifiers return an error and never invoke report generation.
-- `main_test.go:82` - Added a success-path test confirming valid stack identifiers are trimmed and forwarded to report generation.
+- `main_test.go:51` - Added regression tests proving empty and whitespace-only EventBridge stack identifiers return errors and never invoke report generation.
+- `main_test.go:111` - Added a success-path test confirming valid stack identifiers are trimmed and forwarded to report generation.
 
 **Approach rationale:** Validate the event payload at the Lambda boundary, because that is the narrowest point where malformed EventBridge data can be rejected before any AWS-facing report logic runs. The small injection hook keeps the tests fast and deterministic without changing the production code path.
 
@@ -53,9 +53,9 @@ target without its own guard in this call path.
 ## Regression Test
 
 **Test file:** `main_test.go`
-**Test name:** `TestHandleRequestReturnsErrorOnMissingStackID`
+**Test name:** `TestHandleRequestReturnsErrorOnMissingStackID`, `TestHandleRequestReturnsErrorOnWhitespaceOnlyStackID`
 
-**What it verifies:** `HandleRequest` rejects an EventBridge payload with an empty `detail.stack-id` before report generation is invoked.
+**What it verifies:** `HandleRequest` rejects EventBridge payloads whose `detail.stack-id` is empty or blank after trimming before report generation is invoked.
 
 **Run command:** `go test ./... -v`
 


### PR DESCRIPTION
## Summary
- validate and trim EventBridge detail.stack-id in the Lambda handler before starting report generation
- add regression and success-path tests for missing and whitespace-padded stack IDs
- document the fix in the bugfix report

## Testing
- go test ./... -v
- make lint
- go build -o fog